### PR TITLE
Include needed modules on the example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Example
 ```rust
 extern crate minifb;
 
+use minifb::{Key, Scale};
+
 const WIDTH: usize = 640;
 const HEIGHT: usize = 360;
 


### PR DESCRIPTION
The example code on `README.md` requires the `use` line to have the modules available when compiling.
Without it the example can't compile.