### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://travis-ci.org/emoon/rust_minifb.svg)](https://travis-ci.org/emoon/rust_minifb)
 [![Build Status](https://ci.appveyor.com/api/projects/status/sfvgqq4d4sjulkbx?svg=true)](https://ci.appveyor.com/project/emoon/rust-minifb)
 
-minifb is a cross platform library written in [Rust](https://www.rust-lang.org) and that makes it easy to setup a window and to (optional) display 32-bit a pixel buffer.  It also makes it easy to get input from keyboard and mouse.
+minifb is a cross platform library written in [Rust](https://www.rust-lang.org) and that makes it easy to setup a window and to (optional) display a 32-bit pixel buffer.  It also makes it easy to get input from keyboard and mouse.
 An example is the best way to show how it works:
 
 [Documentation](http://prodbg.com/minifb/minifb/index.html)

--- a/examples/title_cursor.rs
+++ b/examples/title_cursor.rs
@@ -61,7 +61,7 @@ fn main() {
         Rect { x: 480, y: 180, width: 160, height: 180, color: 0x00b25091, cursor_style: CursorStyle::ResizeAll }
     ];
 
-    window.set_title("Diffrent cursor on each color region");
+    window.set_title("Different cursor on each color region");
 
     while window.is_open() && !window.is_key_down(Key::Escape) {
         let (mx, my) = window.get_mouse_pos(MouseMode::Clamp).unwrap();

--- a/src/key_handler.rs
+++ b/src/key_handler.rs
@@ -115,7 +115,7 @@ impl KeyHandler {
         if repeat == KeyRepeat::Yes && t > self.key_repeat_delay {
             let delay = self.key_repeat_delay;
             let rate = self.key_repeat_rate;
-            if ((((t - delay) % rate) > rate * 0.5)) != (((t - delay - self.delta_time) % rate) > rate * 0.5) {
+            if (((t - delay) % rate) > rate * 0.5) != (((t - delay - self.delta_time) % rate) > rate * 0.5) {
                 return true;
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -347,7 +347,7 @@ impl Window {
     }
 
     ///
-    /// Set a diffrent cursor style. This can be used if you have resizing
+    /// Set a different cursor style. This can be used if you have resizing
     /// elements or something like that
     ///
     /// # Examples
@@ -749,7 +749,7 @@ impl<'a> MenuItem<'a> {
         }
     }
     #[inline]
-    /// Must be called to finialize building of a menu item when started with ```menu.add_item()```
+    /// Must be called to finalize building of a menu item when started with ```menu.add_item()```
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Hi! IntelliJ Rust noticed a couple of typos and a pair of redundant parenthesis while I was fixing https://github.com/intellij-rust/intellij-rust/issues/551 :) 