### PR TITLE
Improve debug performance of update_with_buffer on windows

### DIFF
--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -639,7 +639,7 @@ impl Window {
 
         Self::generic_update(self, window);
 
-        self.buffer = buffer.iter().cloned().collect();
+        self.buffer = buffer.to_vec();
         unsafe {
             user32::InvalidateRect(window, ptr::null_mut(), winapi::TRUE);
         }


### PR DESCRIPTION
Hello,
I think replacing `buffer.iter().cloned().collect()` with `buffer.to_vec()` can noticeably improve the time spent in `update_with_buffer()` on Windows - Debug builds. 
When compiling with `--release` there is not much of a performance difference.
Here are the times spent in `window.update_with_buffer(&buffer)` using a `1280x720` framebuffer.

|   | Before | After |
|---|---|---|
| Debug | `120 ms` | `52 ms` |
| Release | `2.4 ms` | `2.2 ms` |