### PR TITLE
Fix Redox build

### DIFF
--- a/src/os/redox/mod.rs
+++ b/src/os/redox/mod.rs
@@ -6,7 +6,7 @@ use os::redox::orbclient::Renderer;
 use error::Error;
 use Result;
 use mouse_handler;
-use buffer_height;
+use buffer_helper;
 use key_handler::KeyHandler;
 use InputCallback;
 use {CursorStyle, MouseButton, MouseMode};


### PR DESCRIPTION
A typo in the new bounds checking code (900deba9a7851417c0253b57feba4a089f18b12a) broke the Redox port.