### PR TITLE
Fix Travis-CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ rust:
 matrix:
   allow_failures:
     - rust: nightly
+before_script:
+  - sudo apt-get install xorg-dev


### PR DESCRIPTION
This change should fix the failing builds on travis-ci.
I briefly tested it on my account and everything seems to work.

Not sure if this is the proper way to fix it since anyone who consumes this library and builds on travis ci needs to set the script to apt-get that pkg anyway, but I suppose it's better to see it in the config for the main repro. 

Anyway it's way less painful than rust SDL on windows for example.