### PR TITLE
Update kernel32-sys to 0.2.2 on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ gdi32-sys = "0.1.1"
 [target.x86_64-pc-windows-gnu.dependencies]
 user32-sys = "0.1.2"
 winapi = "0.2.4"
-kernel32-sys = "0.1.4"
+kernel32-sys = "0.2.2"
 gdi32-sys = "0.1.1"
 
 [target.i686-pc-windows-msvc.dependencies]
@@ -43,7 +43,7 @@ gdi32-sys = "0.1.1"
 [target.i686-pc-windows-gnu.dependencies]
 user32-sys = "0.1.2"
 winapi = "0.2.4"
-kernel32-sys = "0.1.4"
+kernel32-sys = "0.2.2"
 gdi32-sys = "0.1.1"
 
 [target.i686-unknown-linux-gnu.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ time = "0.1.34"
 [target.x86_64-pc-windows-msvc.dependencies]
 user32-sys = "0.1.2"
 winapi = "0.2.4"
-kernel32-sys = "0.1.4"
+kernel32-sys = "0.2.2"
 gdi32-sys = "0.1.1"
 
 [target.x86_64-pc-windows-gnu.dependencies]
@@ -37,7 +37,7 @@ gdi32-sys = "0.1.1"
 [target.i686-pc-windows-msvc.dependencies]
 user32-sys = "0.1.2"
 winapi = "0.2.4"
-kernel32-sys = "0.1.4"
+kernel32-sys = "0.2.2"
 gdi32-sys = "0.1.1"
 
 [target.i686-pc-windows-gnu.dependencies]


### PR DESCRIPTION
kernel32-sys 0.1.4 won't compile on my system:

rustc 1.24.0-nightly (8503b3ff8 2017-12-04)
binary: rustc
commit-hash: 8503b3ff822c1ed01c89773d30e4e10b886d77a5
commit-date: 2017-12-04
host: x86_64-pc-windows-gnu
release: 1.24.0-nightly
LLVM version: 4.0