### PR TITLE
Added Window.is_key_released

### DIFF
--- a/src/key_handler.rs
+++ b/src/key_handler.rs
@@ -8,6 +8,7 @@ pub struct KeyHandler {
     prev_time: f64,
     delta_time: f32,
     keys: [bool; 512],
+    keys_prev: [bool; 512],
     keys_down_duration: [f32; 512],
     key_repeat_delay: f32,
     key_repeat_rate: f32,
@@ -18,6 +19,7 @@ impl KeyHandler {
         KeyHandler {
             key_callback: None,
             keys: [false; 512],
+            keys_prev: [false; 512],
             keys_down_duration: [-1.0; 512],
             prev_time: time::precise_time_s(),
             delta_time: 0.0,
@@ -64,6 +66,7 @@ impl KeyHandler {
             } else {
                 self.keys_down_duration[i] = -1.0;
             }
+            self.keys_prev[i] = self.keys[i];
         }
     }
 
@@ -123,7 +126,14 @@ impl KeyHandler {
         return false;
     }
 
+    #[inline]
     pub fn is_key_pressed(&self, key: Key, repeat: KeyRepeat) -> bool {
         return Self::key_pressed(self, key as usize, repeat);
+    }
+
+    #[inline]
+    pub fn is_key_released(&self, key: Key) -> bool {
+        let idx = key as usize;
+        return self.keys_prev[idx] && !self.keys[idx];
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -463,6 +463,14 @@ impl Window {
     }
 
     ///
+    /// Check if a single key was released since last call to update.
+    /// 
+    #[inline]
+    pub fn is_key_released(&self, key: Key) -> bool {
+        self.0.is_key_released(key)
+    }
+
+    ///
     /// Sets the delay for when a key is being held before it starts being repeated the default
     /// value is 0.25 sec
     ///

--- a/src/os/macos/mod.rs
+++ b/src/os/macos/mod.rs
@@ -421,6 +421,11 @@ impl Window {
     }
 
     #[inline]
+    pub fn is_key_released(&self, key: Key) -> bool {
+        self.key_handler.is_key_released(key)
+    }
+
+    #[inline]
     pub fn set_input_callback(&mut self, callback: Box<InputCallback>) {
         self.key_handler.set_input_callback(callback)
     }

--- a/src/os/redox/mod.rs
+++ b/src/os/redox/mod.rs
@@ -202,6 +202,10 @@ impl Window {
         self.key_handler.is_key_pressed(key, repeat)
     }
 
+    pub fn is_key_released(&self, key: Key) -> bool {
+        self.key_handler.is_key_released(key)
+    }
+
     pub fn set_input_callback(&mut self, callback: Box<InputCallback>) {
         self.key_handler.set_input_callback(callback)
     }

--- a/src/os/unix/mod.rs
+++ b/src/os/unix/mod.rs
@@ -354,6 +354,11 @@ impl Window {
     }
 
     #[inline]
+    pub fn is_key_released(&self, key: Key) -> bool {
+        self.key_handler.is_key_released(key)
+    }
+
+    #[inline]
     pub fn set_input_callback(&mut self, callback: Box<InputCallback>)  {
         self.key_handler.set_input_callback(callback)
     }

--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -596,6 +596,11 @@ impl Window {
     }
 
     #[inline]
+    pub fn is_key_released(&self, key: Key) -> bool {
+        self.key_handler.is_key_released(key)
+    }
+
+    #[inline]
     pub fn is_open(&self) -> bool {
         return self.is_open
     }


### PR DESCRIPTION
I'm looking into making a Rust version of @Javidx9 's olcPixelGameEngine: https://github.com/OneLoneCoder/olcPixelGameEngine
Not much progress yet, but a good way to learn Rust for sure!

Anyhow, so far it seems that minifb is the nearest thing I can find that does the low level portion of what I'm trying to do, except for the fact that it doesn't let you determine if a key has just been released.

This PR adds the is_key_released method to address that shortfall.

I guess that the version could be bumped to 0.12.0 as I'm adding a new function, but I figured you could do that if you felt it was in keeping with what you're doing.