### PR TITLE
Bump version to 0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This project follows semantic versioning.
 
+### v0.11.2 (2018-12-19)
+
+- [added] Window.is_key_released
+
 ### v0.11.1 (2018-11-13)
 
 - [fixed] Fixed bad window size in menu example

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minifb"
-version = "0.11.1"
+version = "0.11.2"
 license = "MIT/Apache-2.0"
 authors = ["Daniel Collin <daniel@collin.com>"]
 description = "Cross-platform window setup with optional bitmap rendering"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Usage
 ```toml
 # Cargo.toml
 [dependencies]
-minifb = "0.11.1"
+minifb = "0.11.2"
 ```
 
 Example


### PR DESCRIPTION
I'd like to make the recent 'is_key_released' feature available in the crate on crates.io, and a version bump  seems necessary.
Is this also sufficient, or is there something else that has to be done to get the new version on crates.io?
