### PR TITLE
Add additional derived traits to Key enum

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -1,5 +1,5 @@
 /// Key is used by the get key functions to check if some keys on the keyboard has been pressed
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, PartialOrd, Hash, Clone, Copy)]
 pub enum Key {
     Key0 = 0,
     Key1 = 1,

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,5 +1,5 @@
 /// Key is used by the get key functions to check if some keys on the keyboard has been pressed
-#[derive(Debug, PartialEq, PartialOrd, Hash, Clone, Copy)]
+#[derive(Debug, Eq, PartialEq, PartialOrd, Hash, Clone, Copy)]
 pub enum Key {
     Key0 = 0,
     Key1 = 1,

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,5 +1,5 @@
 /// Key is used by the get key functions to check if some keys on the keyboard has been pressed
-#[derive(Debug, Eq, PartialEq, PartialOrd, Hash, Clone, Copy)]
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone, Copy)]
 pub enum Key {
     Key0 = 0,
     Key1 = 1,


### PR DESCRIPTION
This PR simply adds the `Eq, Ord, PartialOrd and Hash` traits to the derive on top of the Key enum. It allows Keys to be stored in Sets, among other QOL things. 