### PR TITLE
Update winapi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,10 @@ cc = "1.0"
 time = "0.1.34"
 
 [target.'cfg(windows)'.dependencies]
-user32-sys = "0.1.2"
-winapi = "0.2.4"
+user32-sys = "0.1.3"
+winapi = "0.3.6"
 kernel32-sys = "0.2.2"
-gdi32-sys = "0.1.1"
+gdi32-sys = "0.1.2"
 
 [target.i686-unknown-linux-gnu.dependencies]
 x11-dl = "~2.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,7 @@ cc = "1.0"
 time = "0.1.34"
 
 [target.'cfg(windows)'.dependencies]
-user32-sys = "0.1.3"
-#winapi = "0.3.6"
-kernel32-sys = "0.2.2"
-gdi32-sys = "0.1.2"
-
-[target.'cfg(windows)'.dependencies.winapi]
-version = "0.3"
-features = ["everything"]
+winapi = { version = "0.3.6", features = ["everything"]}
 
 [target.i686-unknown-linux-gnu.dependencies]
 x11-dl = "~2.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,13 @@ time = "0.1.34"
 
 [target.'cfg(windows)'.dependencies]
 user32-sys = "0.1.3"
-winapi = "0.3.6"
+#winapi = "0.3.6"
 kernel32-sys = "0.2.2"
 gdi32-sys = "0.1.2"
+
+[target.'cfg(windows)'.dependencies.winapi]
+version = "0.3"
+features = ["everything"]
 
 [target.i686-unknown-linux-gnu.dependencies]
 x11-dl = "~2.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,25 +21,7 @@ cc = "1.0"
 [dependencies]
 time = "0.1.34"
 
-[target.x86_64-pc-windows-msvc.dependencies]
-user32-sys = "0.1.2"
-winapi = "0.2.4"
-kernel32-sys = "0.2.2"
-gdi32-sys = "0.1.1"
-
-[target.x86_64-pc-windows-gnu.dependencies]
-user32-sys = "0.1.2"
-winapi = "0.2.4"
-kernel32-sys = "0.2.2"
-gdi32-sys = "0.1.1"
-
-[target.i686-pc-windows-msvc.dependencies]
-user32-sys = "0.1.2"
-winapi = "0.2.4"
-kernel32-sys = "0.2.2"
-gdi32-sys = "0.1.1"
-
-[target.i686-pc-windows-gnu.dependencies]
+[target.'cfg(windows)'.dependencies]
 user32-sys = "0.1.2"
 winapi = "0.2.4"
 kernel32-sys = "0.2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,14 @@ cc = "1.0"
 [dependencies]
 time = "0.1.34"
 
-[target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.6", features = ["everything"]}
+[target.'cfg(windows)'.dependencies.winapi]
+version = "0.3"
+features = [
+    "winuser",
+    "wingdi",
+    "libloaderapi",
+    "errhandlingapi"
+]
 
 [target.i686-unknown-linux-gnu.dependencies]
 x11-dl = "~2.14"

--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -23,28 +23,18 @@ use std::os::raw;
 use mouse_handler;
 use buffer_helper;
 
-//use self::winapi::windef::HWND;
-//use self::winapi::windef::HDC;
-//use self::winapi::windef::HMENU;
-//use self::winapi::wingdi::BITMAPINFOHEADER;
-//use self::winapi::wingdi::RGBQUAD;
-//use self::winapi::winuser::WNDCLASSW;
-//use self::winapi::winuser::ACCEL;
-//use self::winapi::basetsd::UINT_PTR;
-use self::winapi::*;
 use self::winapi::shared::basetsd::*;
 use self::winapi::um::winuser;
 use self::winapi::shared::minwindef::*;
 use self::winapi::shared::windef::{self, *};
 use self::winapi::um::wingdi;
 use self::winapi::shared::ntdef;
-//use self::winapi::winmindefs::BYTE;
 
 // Wrap this so we can have a proper numbef of bmiColors to write in
 #[repr(C)]
 struct BitmapInfo {
-    pub bmi_header: BITMAPINFOHEADER,
-    pub bmi_colors: [RGBQUAD; 3],
+    pub bmi_header: wingdi::BITMAPINFOHEADER,
+    pub bmi_colors: [wingdi::RGBQUAD; 3],
 }
 
 fn update_key_state(window: &mut Window, wparam: u32, state: bool) {
@@ -159,30 +149,30 @@ fn char_down(window: &mut Window, code_point: u32) {
 }
 
 #[cfg(target_arch = "x86_64")]
-unsafe fn set_window_long(window: winapi::HWND, data: winapi::LONG_PTR) -> winapi::LONG_PTR {
+unsafe fn set_window_long(window: windef::HWND, data: LONG_PTR) -> LONG_PTR {
     winuser::SetWindowLongPtrW(window, winuser::GWLP_USERDATA, data)
 }
 
 #[cfg(target_arch = "x86_64")]
-unsafe fn get_window_long(window: winapi::HWND) -> winapi::LONG_PTR {
+unsafe fn get_window_long(window: windef::HWND) -> LONG_PTR {
     winuser::GetWindowLongPtrW(window, winuser::GWLP_USERDATA)
 }
 
 #[cfg(target_arch = "x86")]
-unsafe fn set_window_long(window: winapi::HWND, data: ntdef::LONG) -> ntdef::LONG {
+unsafe fn set_window_long(window: windef::HWND, data: ntdef::LONG) -> ntdef::LONG {
     winuser::SetWindowLongW(window, winuser::GWLP_USERDATA, data)
 }
 
 #[cfg(target_arch = "x86")]
-unsafe fn get_window_long(window: winapi::HWND) -> ntdef::LONG {
+unsafe fn get_window_long(window: windef::HWND) -> ntdef::LONG {
     winuser::GetWindowLongW(window, winuser::GWLP_USERDATA)
 }
 
-unsafe extern "system" fn wnd_proc(window: winapi::HWND,
-                                   msg: winapi::UINT,
-                                   wparam: winapi::WPARAM,
-                                   lparam: winapi::LPARAM)
-                                   -> winapi::LRESULT {
+unsafe extern "system" fn wnd_proc(window: windef::HWND,
+                                   msg: UINT,
+                                   wparam: WPARAM,
+                                   lparam: LPARAM)
+                                   -> LRESULT {
     // This make sure we actually don't do anything before the user data has been setup for the
     // window
 
@@ -278,7 +268,7 @@ unsafe extern "system" fn wnd_proc(window: winapi::HWND,
 
             let mut bitmap_info: BitmapInfo = mem::zeroed();
 
-            bitmap_info.bmi_header.biSize = mem::size_of::<BITMAPINFOHEADER>() as u32;
+            bitmap_info.bmi_header.biSize = mem::size_of::<wingdi::BITMAPINFOHEADER>() as u32;
             bitmap_info.bmi_header.biPlanes = 1;
             bitmap_info.bmi_header.biBitCount = 32;
             bitmap_info.bmi_header.biCompression = wingdi::BI_BITFIELDS;
@@ -352,7 +342,7 @@ pub struct Window {
     accel_table: HACCEL,
     accel_key: usize,
     prev_cursor: CursorStyle,
-    cursors: [winapi::HCURSOR; 8],
+    cursors: [windef::HCURSOR; 8],
 }
 
 // TranslateAccelerator is currently missing in win-rs
@@ -367,8 +357,8 @@ impl Window {
     fn open_window(name: &str, width: usize, height: usize, opts: WindowOptions, scale_factor: i32) -> Option<HWND> {
         unsafe {
             let class_name = to_wstring("minifb_window");
-            let class = WNDCLASSW {
-                style: winapi::CS_HREDRAW | winapi::CS_VREDRAW | winapi::CS_OWNDC,
+            let class = winuser::WNDCLASSW {
+                style: winuser::CS_HREDRAW | winuser::CS_VREDRAW | winuser::CS_OWNDC,
                 lpfnWndProc: Some(wnd_proc),
                 cbClsExtra: 0,
                 cbWndExtra: 0,
@@ -391,7 +381,7 @@ impl Window {
             let new_width = width * scale_factor as usize;
             let new_height = height * scale_factor as usize;
 
-            let mut rect = winapi::RECT {
+            let mut rect = windef::RECT {
                 left: 0,
                 right: new_width as ntdef::LONG,
                 top: 0,

--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -1,9 +1,6 @@
 #![cfg(target_os = "windows")]
 
-//extern crate user32;
-extern crate kernel32;
 extern crate winapi;
-extern crate gdi32;
 extern crate time;
 
 const INVALID_ACCEL: usize = 0xffffffff;
@@ -29,6 +26,8 @@ use self::winapi::shared::minwindef::*;
 use self::winapi::shared::windef::{self, *};
 use self::winapi::um::wingdi;
 use self::winapi::shared::ntdef;
+use self::winapi::um::libloaderapi;
+use self::winapi::um::errhandlingapi;
 
 // Wrap this so we can have a proper numbef of bmiColors to write in
 #[repr(C)]
@@ -278,7 +277,7 @@ unsafe extern "system" fn wnd_proc(window: windef::HWND,
             bitmap_info.bmi_colors[1].rgbGreen = 0xff;
             bitmap_info.bmi_colors[2].rgbBlue = 0xff;
 
-            gdi32::StretchDIBits(wnd.dc.unwrap(),
+            wingdi::StretchDIBits(wnd.dc.unwrap(),
                                  0,
                                  0,
                                  wnd.width * wnd.scale_factor,
@@ -362,7 +361,7 @@ impl Window {
                 lpfnWndProc: Some(wnd_proc),
                 cbClsExtra: 0,
                 cbWndExtra: 0,
-                hInstance: kernel32::GetModuleHandleA(ptr::null()),
+                hInstance: libloaderapi::GetModuleHandleA(ptr::null()),
                 hIcon: ptr::null_mut(),
                 hCursor: ptr::null_mut(),
                 hbrBackground: ptr::null_mut(),
@@ -372,8 +371,8 @@ impl Window {
 
             if winuser::RegisterClassW(&class) == 0 {
                 // ignore the "Class already exists" error for multiple windows
-                if kernel32::GetLastError() as u32 != 1410 {
-                    println!("Unable to register class, error {}", kernel32::GetLastError() as u32);
+                if errhandlingapi::GetLastError() as u32 != 1410 {
+                    println!("Unable to register class, error {}", errhandlingapi::GetLastError() as u32);
                     return None;
                 }
             }
@@ -428,7 +427,7 @@ impl Window {
                                                  ptr::null_mut(),
                                                  ptr::null_mut());
             if handle.is_null() {
-                println!("Unable to create window, error {}", kernel32::GetLastError() as u32);
+                println!("Unable to create window, error {}", errhandlingapi::GetLastError() as u32);
                 return None;
             }
 


### PR DESCRIPTION
Updates winapi to version 0.3.
Removes user32-sys, kernel32-sys and gdi32-sys, they are no longer needed, because they are provided by winapi-rs.

Also removed star glob imports, some of the imported symbols are quite generic and this way it is also more consistent with the rest of the code.

Closes #53 