### PR TITLE
x11 and examples: resize

### DIFF
--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -10,6 +10,7 @@ fn main() {
 
     let mut window = match Window::new("Mouse Draw - Press ESC to exit", WIDTH, HEIGHT,
                                        WindowOptions {
+                                           resize: true,
                                            scale: Scale::X2,
                                            ..WindowOptions::default()
                                        }) {
@@ -20,9 +21,29 @@ fn main() {
         }
     };
 
+    let (mut width, mut height) = (WIDTH, HEIGHT);
+
     while window.is_open() && !window.is_key_down(Key::Escape) {
-        window.get_mouse_pos(MouseMode::Discard).map(|mouse| {
-            let screen_pos = ((mouse.1 as usize) * WIDTH) + mouse.0 as usize;
+        {
+            let (new_width, new_height) = window.get_size();
+            if new_width != width || new_height != height {
+
+                // copy valid bits of old buffer to new buffer
+                let mut new_buffer = vec![0; new_width * new_height / 2 / 2];
+                for y in 0..(height / 2).min(new_height / 2) {
+                    for x in 0..(width / 2).min(new_width / 2) {
+                        new_buffer[y * (new_width / 2) + x] = buffer[y * (width / 2) + x];
+                    }
+                }
+                buffer = new_buffer;
+                width = new_width;
+                height = new_height;
+
+            }
+        }
+
+        window.get_mouse_pos(MouseMode::Discard).map(|(x, y)| {
+            let screen_pos = ((y as usize) * width / 2) + x as usize;
             println!("{:?}", window.get_unscaled_mouse_pos(MouseMode::Discard).unwrap());
 
             if window.get_mouse_down(MouseButton::Left) {

--- a/examples/multi.rs
+++ b/examples/multi.rs
@@ -6,15 +6,15 @@ fn main() {
     let width = 640;
     let height = 320;
     let mut buffer = vec![0u32; width * height];
-    let mut orig = Window::new("Smaller", width, height, WindowOptions {
-        resize: true,
-        ..WindowOptions::default()
-    }).unwrap();
     let mut double = Window::new("Larger", width, height, WindowOptions {
-        resize: true,
         scale: Scale::X2,
         ..WindowOptions::default()
     }).unwrap();
+
+    let mut orig = Window::new("Smaller", width, height, WindowOptions {
+        ..WindowOptions::default()
+    }).unwrap();
+
 
     let mut pos = 13;
 

--- a/examples/noise.rs
+++ b/examples/noise.rs
@@ -2,7 +2,7 @@ extern crate minifb;
 
 use minifb::{Window, Key, Scale, WindowOptions};
 
-const WIDTH: usize = 640;
+const WIDTH: usize = 2560;
 const HEIGHT: usize = 360;
 
 fn main() {
@@ -10,7 +10,6 @@ fn main() {
     let mut carry;
     let mut seed = 0xbeefu32;
 
-    let mut buffer: Vec<u32> = vec![0; WIDTH * HEIGHT];
 
     let mut window = match Window::new("Noise Test - Press ESC to exit", WIDTH, HEIGHT,
                                        WindowOptions {
@@ -25,7 +24,19 @@ fn main() {
         }
     };
 
+    let mut buffer: Vec<u32> = Vec::with_capacity(WIDTH * HEIGHT);
+
+    let mut size = (0, 0);
+
     while window.is_open() && !window.is_key_down(Key::Escape) {
+        {
+            let new_size = window.get_size();
+            if new_size != size {
+                size = new_size;
+                buffer.resize(size.0 * size.1 / 2 / 2, 0);
+            }
+        }
+
         for i in buffer.iter_mut() {
             noise = seed;
             noise >>= 3;

--- a/examples/title_cursor.rs
+++ b/examples/title_cursor.rs
@@ -45,7 +45,6 @@ fn main() {
                                  WIDTH,
                                  HEIGHT,
                                  WindowOptions {
-                                     resize: true,
                                      scale: Scale::X2,
                                      ..WindowOptions::default()
                                  })

--- a/src/os/unix/key_mapping.rs
+++ b/src/os/unix/key_mapping.rs
@@ -881,8 +881,8 @@ pub fn keysym_to_unicode(keysym: u32) -> Option<u32> {
     }
 
     // Also check for directly encoded 24-bit UCS characters
-    if (keysym & 0xff000000) == 0x01000000 {
-        return Some(keysym & 0x00ffffff);
+    if (keysym & 0xff00_0000) == 0x0100_0000 {
+        return Some(keysym & 0x00ff_ffff);
     }
 
     // Binary search in table
@@ -905,9 +905,7 @@ pub fn test_it() {
     }
 
     // check ability to find every value in the table
-    for i in 0..LENGTH {
-        let p = keysymtab[i];
-
+    for p in keysymtab.iter() {
         assert_eq!(keysym_to_unicode(p.0), Some(p.1));
     }
 }

--- a/src/os/unix/mod.rs
+++ b/src/os/unix/mod.rs
@@ -311,9 +311,7 @@ impl Window {
             if opts.resize {
                 let mut size_hints: xlib::XSizeHints = mem::zeroed();
 
-                size_hints.flags = xlib::PPosition | xlib::PMinSize | xlib::PMaxSize;
-                size_hints.x = 0;
-                size_hints.y = 0;
+                size_hints.flags = xlib::PMinSize | xlib::PMaxSize;
                 size_hints.min_width = width as i32;
                 size_hints.max_width = width as i32;
                 size_hints.min_height = height as i32;

--- a/src/os/unix/mod.rs
+++ b/src/os/unix/mod.rs
@@ -308,7 +308,7 @@ impl Window {
                     | xlib::ButtonReleaseMask,
             );
 
-            if opts.resize {
+            if !opts.resize {
                 let mut size_hints: xlib::XSizeHints = mem::zeroed();
 
                 size_hints.flags = xlib::PMinSize | xlib::PMaxSize;


### PR DESCRIPTION
Handle, to some extent, resizing under x11.

The middle of the event loop is perhaps not the best place to reallocate the image, but it is the simplest. Specifically, there are issues with error handling; at the moment, it just panics (`expect`).

I also fiddled the examples, `noise` and `mouse` now support resizing properly (i.e. they handle updating the buffer), and `multi` and `title_cursor` ask for non-resizable windows.

This should hopefully finally fix #66. It may introduce #71.
