### PR TITLE
fix 'attempt to subtract with overflow' bug

### DIFF
--- a/src/os/unix/mod.rs
+++ b/src/os/unix/mod.rs
@@ -275,7 +275,7 @@ impl Window {
             attributes.backing_store = xlib::NotUseful;
 
             let x = if d.screen_width > width { (d.screen_width - width) / 2 } else { 0 };
-            let y = id d.screen_height > height { (d.screen_height - height) / 2 } else { 0 };
+            let y = if d.screen_height > height { (d.screen_height - height) / 2 } else { 0 };
 
             let handle = (d.lib.XCreateWindow)(
                 d.display,

--- a/src/os/unix/mod.rs
+++ b/src/os/unix/mod.rs
@@ -274,8 +274,8 @@ impl Window {
 
             attributes.backing_store = xlib::NotUseful;
 
-            let x = (d.screen_width - width) / 2;
-            let y = (d.screen_height - height) / 2;
+            let x = if d.screen_width > width { (d.screen_width - width) / 2 } else { 0 };
+            let y = id d.screen_height > height { (d.screen_height - height) / 2 } else { 0 };
 
             let handle = (d.lib.XCreateWindow)(
                 d.display,


### PR DESCRIPTION
A program which creates a window with this library when the requested window size is taller than the screen size will crash because the two following lines do not take into this case.
```rust
let x = (d.screen_width - width) / 2;
let y = (d.screen_height - height) / 2;
```

The patchwork assigns this processed value when the window size is smaller than the screen size or 0 else.