### PR TITLE
add get_keys_released method to Window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target
 Cargo.lock
+*.idea
+*.iml

--- a/examples/noise.rs
+++ b/examples/noise.rs
@@ -58,6 +58,16 @@ fn main() {
             }
         });
 
+        window.get_keys_released().map(|keys| {
+            for t in keys {
+                match t {
+                    Key::W => println!("released w!"),
+                    Key::T => println!("released t!"),
+                    _ => (),
+                }
+            }
+        });
+
         window
             .update_with_buffer(&buffer, new_size.0, new_size.1)
             .unwrap();

--- a/src/key_handler.rs
+++ b/src/key_handler.rs
@@ -91,6 +91,20 @@ impl KeyHandler {
         Some(keys)
     }
 
+    pub fn get_keys_released(&self) -> Option<Vec<Key>> {
+        let mut keys: Vec<Key> = Vec::new();
+
+        for (idx, is_down) in self.keys.iter().enumerate() {
+            if !(*is_down) && self.is_key_index_released(idx) {
+                unsafe {
+                    keys.push(mem::transmute(idx as u8));
+                }
+            }
+        }
+
+        Some(keys)
+    }
+
     #[inline]
     pub fn is_key_down(&self, key: Key) -> bool {
         return self.keys[key as usize];
@@ -134,6 +148,11 @@ impl KeyHandler {
     #[inline]
     pub fn is_key_released(&self, key: Key) -> bool {
         let idx = key as usize;
+        return self.is_key_index_released(idx);
+    }
+
+    #[inline]
+    fn is_key_index_released(&self, idx: usize) -> bool {
         return self.keys_prev[idx] && !self.keys[idx];
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -562,6 +562,29 @@ impl Window {
     }
 
     ///
+    /// Get the current released keys.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use minifb::*;
+    /// # let mut window = Window::new("Test", 640, 400, WindowOptions::default()).unwrap();
+    /// window.get_keys_released().map(|keys| {
+    ///     for t in keys {
+    ///         match t {
+    ///             Key::W => println!("released w"),
+    ///             Key::T => println!("released t"),
+    ///             _ => (),
+    ///         }
+    ///     }
+    /// });
+    /// ```
+    #[inline]
+    pub fn get_keys_released(&self) -> Option<Vec<Key>> {
+        self.0.get_keys_released()
+    }
+
+    ///
     /// Check if a single key is down.
     ///
     /// # Examples

--- a/src/os/macos/mod.rs
+++ b/src/os/macos/mod.rs
@@ -469,6 +469,11 @@ impl Window {
     }
 
     #[inline]
+    pub fn get_keys_released(&self) -> Option<Vec<Key>> {
+        self.key_handler.get_keys_released()
+    }
+
+    #[inline]
     pub fn is_key_down(&self, key: Key) -> bool {
         self.key_handler.is_key_down(key)
     }

--- a/src/os/redox/mod.rs
+++ b/src/os/redox/mod.rs
@@ -189,6 +189,10 @@ impl Window {
         self.key_handler.get_keys_pressed(repeat)
     }
 
+    pub fn get_keys_released(&self) -> Option<Vec<Key>> {
+        self.key_handler.get_keys_released()
+    }
+
     pub fn is_key_down(&self, key: Key) -> bool {
         self.key_handler.is_key_down(key)
     }

--- a/src/os/unix/mod.rs
+++ b/src/os/unix/mod.rs
@@ -155,6 +155,13 @@ impl Window {
         }
     }
 
+    pub fn get_keys_released(&self) -> Option<Vec<Key>> {
+        match *self {
+            Window::X11(ref w) => w.get_keys_released(),
+            Window::Wayland(ref _w) => unimplemented!(),
+        }
+    }
+
     pub fn is_key_down(&self, key: Key) -> bool {
         match *self {
             Window::X11(ref w) => w.is_key_down(key),

--- a/src/os/unix/x11.rs
+++ b/src/os/unix/x11.rs
@@ -591,6 +591,11 @@ impl Window {
     }
 
     #[inline]
+    pub fn get_keys_released(&self) -> Option<Vec<Key>> {
+        self.key_handler.get_keys_released()
+    }
+
+    #[inline]
     pub fn is_key_down(&self, key: Key) -> bool {
         self.key_handler.is_key_down(key)
     }

--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -701,6 +701,11 @@ impl Window {
     }
 
     #[inline]
+    pub fn get_keys_released(&self) -> Option<Vec<Key>> {
+        self.key_handler.get_keys_released()
+    }
+
+    #[inline]
     pub fn is_key_down(&self, key: Key) -> bool {
         self.key_handler.is_key_down(key)
     }


### PR DESCRIPTION
See #150 

Adds a method `get_keys_released` to all `Window` implementations and extends the noise example to call it. This is the inverse of `get_keys_pressed` method in that it will fill the returned `Vec` with `Keys` that were released in the last update, rather than pressed.