### PR TITLE
Added Topmost/Always on Top functionality to MacOS 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,8 @@ pub struct WindowOptions {
     pub scale: Scale,
     /// Adjust how the scaling of the buffer used with update_with_buffer should be done.
     pub scale_mode: ScaleMode,
+    /// Should the window be the topmost window (default: false)
+    pub topmost: bool,
 }
 
 impl Window {
@@ -995,6 +997,7 @@ impl Default for WindowOptions {
             resize: false,
             scale: Scale::X1,
             scale_mode: ScaleMode::Stretch,
+            topmost: false,
         }
     }
 }

--- a/src/native/macosx/MacMiniFB.m
+++ b/src/native/macosx/MacMiniFB.m
@@ -292,6 +292,23 @@ void* mfb_open(const char* name, int width, int height, uint32_t flags, int scal
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+// Sets whether window is the topmost window
+void mfb_topmost(void* win, bool topmost)
+{
+
+	OSXWindow* window = (OSXWindow*)win;
+
+	if(topmost)
+	{
+		window.level = NSFloatingWindowLevel; // set level to floating
+	} else 
+	{
+		window.level = 0; // set to default/normal
+	}
+
+}
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 static NSString* findAppName(void)
 {
     size_t i;

--- a/src/native/macosx/MacMiniFB.m
+++ b/src/native/macosx/MacMiniFB.m
@@ -293,17 +293,17 @@ void* mfb_open(const char* name, int width, int height, uint32_t flags, int scal
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 // Sets whether window is the topmost window
-void mfb_topmost(void* win, bool topmost)
+void mfb_topmost(void* window, bool topmost)
 {
 
-	OSXWindow* window = (OSXWindow*)win;
+	OSXWindow* win = (OSXWindow*)window;
 
 	if(topmost)
 	{
-		window.level = NSFloatingWindowLevel; // set level to floating
+		win.level = NSFloatingWindowLevel; // set level to floating
 	} else 
 	{
-		window.level = 0; // set to default/normal
+		win.level = 0; // set to default/normal
 	}
 
 }

--- a/src/os/macos/mod.rs
+++ b/src/os/macos/mod.rs
@@ -192,6 +192,9 @@ extern "C" {
     fn mfb_create_menu(name: *const c_char) -> *mut c_void;
     fn mfb_remove_menu_at(window: *mut c_void, index: i32);
 
+    /// Sets the whether or not the window is the topmost window
+    fn mfb_topmost(window: *mut c_void, topmost: bool);
+
     fn mfb_add_menu_item(
         menu_item: *mut c_void,
         menu_id: i32,
@@ -287,6 +290,11 @@ impl Window {
                 scale_factor as i32,
                 &mut view_handle,
             );
+
+
+            if opts.topmost { 
+                mfb_topmost(handle, true);
+            }
 
             if handle == ptr::null_mut() {
                 return Err(Error::WindowCreate("Unable to open Window".to_owned()));


### PR DESCRIPTION
This functionality is useful for utility apps that he developer wants to float above other windows

WindowOptions now has a topmost property denoting whether the window should be the topmost window.  The mfb_topmost function will set the NSWindow level property to NSFloatingWindowLevel if WindowOptions::topmost is true, otherwise it will be 0 (normal).