### PR TITLE
Removing some legacy Debug information

### DIFF
--- a/src/native/macosx/MacMiniFB.m
+++ b/src/native/macosx/MacMiniFB.m
@@ -114,8 +114,6 @@ static bool create_shaders() {
 		return false;
 	}
 
-	NSLog(@"Names %@", [g_library functionNames]);
-
 	g_library = library;
 
 	id<MTLFunction> vertex_shader_func = [g_library newFunctionWithName:@"vertFunc"];


### PR DESCRIPTION
Removed NSLog(@"Names %@", [g_library functionNames]); debug call from src/native/macosx/MacMiniFB.m