### PR TITLE
Added Topmost (always on top) functionality to Windows

### DIFF
--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -7,7 +7,6 @@ const HEIGHT: usize = 360;
 
 fn main() {
     let mut buffer: Vec<u32> = vec![0; WIDTH * HEIGHT];
-
     let mut window = match Window::new(
         "Mouse Draw - Press ESC to exit",
         WIDTH,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,7 +350,7 @@ impl Window {
         self.0.set_position(x, y)
     }
 
-      ///
+    ///
     /// Makes the window the topmost window and makes it stay always on top. This is useful if you
     /// want the window to float above all over windows
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,7 +185,7 @@ pub struct WindowOptions {
     pub scale: Scale,
     /// Adjust how the scaling of the buffer used with update_with_buffer should be done.
     pub scale_mode: ScaleMode,
-    /// Should the window be the topmost window (default: false)
+    /// Should the window be the topmost window and always on top (default: false)
     pub topmost: bool,
 }
 
@@ -348,6 +348,24 @@ impl Window {
     #[inline]
     pub fn set_position(&mut self, x: isize, y: isize) {
         self.0.set_position(x, y)
+    }
+
+      ///
+    /// Makes the window the topmost window and makes it stay always on top. This is useful if you
+    /// want the window to float above all over windows
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use minifb::*;
+    /// # let mut window = Window::new("Test", 640, 400, WindowOptions::default()).unwrap();
+    /// // Makes the window always on top
+    /// window.topmost(true);
+    /// ```
+    ///
+    #[inline]
+    pub fn topmost(&self, topmost: bool) {
+        self.0.topmost(topmost)
     }
 
     ///

--- a/src/native/macosx/MacMiniFB.m
+++ b/src/native/macosx/MacMiniFB.m
@@ -114,8 +114,6 @@ static bool create_shaders() {
 		return false;
 	}
 
-	NSLog(@"Names %@", [g_library functionNames]);
-
 	g_library = library;
 
 	id<MTLFunction> vertex_shader_func = [g_library newFunctionWithName:@"vertFunc"];

--- a/src/os/macos/mod.rs
+++ b/src/os/macos/mod.rs
@@ -402,6 +402,11 @@ impl Window {
         unsafe { mfb_set_position(self.window_handle, x as i32, y as i32) }
     }
 
+    #[inline]
+    pub fn topmost(&self, topmost: bool) {
+        unsafe { mfb_topmost(self.window_handle, topmost) }
+    }
+
     pub fn get_size(&self) -> (usize, usize) {
         (
             self.shared_data.width as usize,

--- a/src/os/unix/mod.rs
+++ b/src/os/unix/mod.rs
@@ -85,6 +85,14 @@ impl Window {
         }
     }
 
+    pub fn topmost(&self, topmost: bool) {
+        match *self {
+            // We will just do nothing until it is implemented so that nothing breaks
+            Window::X11(ref mut w) => (),
+            Window::Wayland(ref mut _w) => (),
+        }
+    }
+
     pub fn get_size(&self) -> (usize, usize) {
         match *self {
             Window::X11(ref w) => w.get_size(),

--- a/src/os/unix/mod.rs
+++ b/src/os/unix/mod.rs
@@ -85,12 +85,9 @@ impl Window {
         }
     }
 
-    pub fn topmost(&self, topmost: bool) {
-        match *self {
+    pub fn topmost(&self, _topmost: bool) {
             // We will just do nothing until it is implemented so that nothing breaks
-            Window::X11(ref mut w) => (),
-            Window::Wayland(ref mut _w) => (),
-        }
+            ()
     }
 
     pub fn get_size(&self) -> (usize, usize) {

--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -644,7 +644,7 @@ impl Window {
     pub fn topmost(&self, topmost: bool) {
         unsafe {
             match topmost {
-                true => winuser::SetWindowPos( 
+                true => winuser::SetWindowPos(
                     self.window.unwrap(),
                     winuser::HWND_TOPMOST,
                     0,
@@ -661,11 +661,10 @@ impl Window {
                     0,
                     0,
                     winuser::SWP_SHOWWINDOW | winuser::SWP_NOSIZE | winuser::SWP_NOMOVE,
-                )
+                ),
             }
         };
     }
-    
 
     #[inline]
     pub fn get_size(&self) -> (usize, usize) {

--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -604,6 +604,10 @@ impl Window {
                 },
             };
 
+            if opts.topmost {
+                window.topmost(true);
+            }
+
             Ok(window)
         }
     }
@@ -635,6 +639,33 @@ impl Window {
             );
         }
     }
+
+    #[inline]
+    pub fn topmost(&self, topmost: bool) {
+        unsafe {
+            match topmost {
+                true => winuser::SetWindowPos( 
+                    self.window.unwrap(),
+                    winuser::HWND_TOPMOST,
+                    0,
+                    0,
+                    0,
+                    0,
+                    winuser::SWP_SHOWWINDOW | winuser::SWP_NOSIZE | winuser::SWP_NOMOVE,
+                ),
+                false => winuser::SetWindowPos(
+                    self.window.unwrap(),
+                    winuser::HWND_TOP,
+                    0,
+                    0,
+                    0,
+                    0,
+                    winuser::SWP_SHOWWINDOW | winuser::SWP_NOSIZE | winuser::SWP_NOMOVE,
+                )
+            }
+        };
+    }
+    
 
     #[inline]
     pub fn get_size(&self) -> (usize, usize) {


### PR DESCRIPTION
Added always on top functionality to Windows. Topmost functionality (always on top) can be achieved at window creation by setting WindowOptions::topmost to true, or after creation by calling Window::topmost(bool). This api works on MacOS and Windows.

I tested the Windows implementation using Wine. I'm assuming it will work properly on a real machine. On unix instead of calling unimplemented! The topmost function just returns void so that nothing breaks