### PR TITLE
Added Topmost (always on top) functionality to Windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -370,7 +370,6 @@ impl Window {
         self.0.topmost(topmost)
     }
 
-
     ///
     /// Sets the background color that is used with update_with_buffer.
     /// In some cases there will be a blank area around the buffer depending on the ScaleMode that has been set.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -353,6 +353,25 @@ impl Window {
     }
 
     ///
+    /// Makes the window the topmost window and makes it stay always on top. This is useful if you
+    /// want the window to float above all over windows
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use minifb::*;
+    /// # let mut window = Window::new("Test", 640, 400, WindowOptions::default()).unwrap();
+    /// // Makes the window always on top
+    /// window.topmost(true);
+    /// ```
+    ///
+    #[inline]
+    pub fn topmost(&self, topmost: bool) {
+        self.0.topmost(topmost)
+    }
+
+
+    ///
     /// Sets the background color that is used with update_with_buffer.
     /// In some cases there will be a blank area around the buffer depending on the ScaleMode that has been set.
     /// This color will be used in the in that area.

--- a/src/os/macos/mod.rs
+++ b/src/os/macos/mod.rs
@@ -410,6 +410,11 @@ impl Window {
         unsafe { mfb_set_position(self.window_handle, x as i32, y as i32) }
     }
 
+    #[inline]
+    pub fn topmost(&self, topmost: bool) {
+        unsafe { mfb_topmost(self.window_handle, topmost) }
+    }
+
     pub fn get_size(&self) -> (usize, usize) {
         (
             self.shared_data.width as usize,

--- a/src/os/posix/mod.rs
+++ b/src/os/posix/mod.rs
@@ -129,6 +129,12 @@ impl Window {
         }
     }
 
+
+    pub fn topmost(&self, _topmost: bool) {
+        // We will just do nothing until it is implemented so that nothing breaks
+        ()
+    }
+
     pub fn get_size(&self) -> (usize, usize) {
         match *self {
             #[cfg(feature = "x11")]

--- a/src/os/posix/mod.rs
+++ b/src/os/posix/mod.rs
@@ -129,7 +129,6 @@ impl Window {
         }
     }
 
-
     pub fn topmost(&self, _topmost: bool) {
         // We will just do nothing until it is implemented so that nothing breaks
         ()

--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -647,6 +647,25 @@ impl Window {
     }
 
     #[inline]
+    pub fn topmost(&self, topmost: bool) {
+        unsafe {
+            winuser::SetWindowPos(
+                self.window.unwrap(),
+                if topmost == true {
+                    winuser::HWND_TOPMOST
+                } else {
+                    winuser::HWND_TOP
+                },
+                0,
+                0,
+                0,
+                0,
+                winuser::SWP_SHOWWINDOW | winuser::SWP_NOSIZE | winuser::SWP_NOMOVE,
+            )
+        };
+    }
+    
+    #[inline]
     pub fn get_size(&self) -> (usize, usize) {
         (self.width as usize, self.height as usize)
     }

--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -664,7 +664,7 @@ impl Window {
             )
         };
     }
-    
+
     #[inline]
     pub fn get_size(&self) -> (usize, usize) {
         (self.width as usize, self.height as usize)

--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -1009,25 +1009,6 @@ impl Window {
             Some(t)
         }
     }
-
-    #[inline]
-    fn topmost(&self, topmost: bool) {
-        unsafe {
-            winuser::SetWindowPos(
-                self.window.unwrap(),
-                if topmost == true {
-                    winuser::HWND_TOPMOST
-                } else {
-                    winuser::HWND_TOP
-                },
-                0,
-                0,
-                0,
-                0,
-                winuser::SWP_SHOWWINDOW | winuser::SWP_NOSIZE | winuser::SWP_NOMOVE,
-            );
-        }
-    }
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
Added always on top functionality to Windows. Topmost functionality (always on top) can be achieved at window creation by setting WindowOptions::topmost to true, or after creation by calling Window::topmost(bool). This api works on MacOS and Windows.

I tested the Windows implementation using Wine. I'm assuming it will work properly on a real machine. On unix instead of calling unimplemented! The topmost function just returns void so that nothing breaks