### PR TITLE
Make Linux/BSD targets much more generic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,61 +39,7 @@ features = [
     "errhandlingapi"
 ]
 
-[target.i686-unknown-linux-gnu.dependencies]
-x11-dl = "2.18.3"
-wayland-client = "0.25"
-wayland-protocols = { version = "0.25", features = ["client"] }
-tempfile = "3.1.0"
-
-[target.x86_64-unknown-linux-gnu.dependencies]
-x11-dl = "2.18.3"
-wayland-client = "0.25"
-wayland-protocols = { version = "0.25", features = ["client"] }
-tempfile = "3.1.0"
-
-[target.arm-unknown-linux-gnueabihf.dependencies]
-x11-dl = "2.18.3"
-wayland-client = "0.25"
-wayland-protocols = { version = "0.25", features = ["client"] }
-tempfile = "3.1.0"
-
-[target.armv7-unknown-linux-gnueabihf.dependencies]
-x11-dl = "2.18.3"
-wayland-client = "0.25"
-wayland-protocols = { version = "0.25", features = ["client"] }
-tempfile = "3.1.0"
-
-[target.aarch64-unknown-linux-gnu.dependencies]
-x11-dl = "2.18.3"
-wayland-client = "0.25"
-wayland-protocols = { version = "0.25", features = ["client"] }
-tempfile = "3.1.0"
-
-[target.x86_64-unknown-dragonfly.dependencies]
-x11-dl = "2.18.3"
-wayland-client = "0.25"
-wayland-protocols = { version = "0.25", features = ["client"] }
-tempfile = "3.1.0"
-
-[target.armv6-unknown-freebsd.dependencies]
-x11-dl = "2.18.3"
-wayland-client = "0.25"
-wayland-protocols = { version = "0.25", features = ["client"] }
-tempfile = "3.1.0"
-
-[target.armv7-unknown-freebsd.dependencies]
-x11-dl = "2.18.3"
-wayland-client = "0.25"
-wayland-protocols = { version = "0.25", features = ["client"] }
-tempfile = "3.1.0"
-
-[target.aarch64-unknown-freebsd.dependencies]
-x11-dl = "2.18.3"
-wayland-client = "0.25"
-wayland-protocols = { version = "0.25", features = ["client"] }
-tempfile = "3.1.0"
-
-[target.x86_64-unknown-freebsd.dependencies]
+[target.'cfg(unix)'.dependencies]
 x11-dl = "2.18.3"
 wayland-client = "0.25"
 wayland-protocols = { version = "0.25", features = ["client"] }


### PR DESCRIPTION
This will allow for the codebase to compile on all UNIX targets (which all realistically support X11 in some capacity, including Mac OS), and allow for the code to build on unspecified UNIX targets, such as musl-based linux targets.