### PR TITLE
Add method for updating the buffer only

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ fn main() {
         }
 
         // We unwrap here as we want this code to exit if it fails. Real applications may want to handle this in a different way
+        window.update();
         window
             .update_with_buffer(&buffer, WIDTH, HEIGHT)
             .unwrap();

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -32,8 +32,9 @@ fn main() {
     .expect("Unable to open Window");
 
     while window.is_open() && !window.is_key_down(Key::Escape) {
+        window.update();
         window
-            .update_with_buffer(&u32_buffer, info.width as usize, info.height as usize)
+            .update_buffer(&u32_buffer, info.width as usize, info.height as usize)
             .unwrap();
     }
 }

--- a/examples/julia.rs
+++ b/examples/julia.rs
@@ -61,7 +61,8 @@ fn main() {
         angle += 0.1;
 
         // We unwrap here as we want this code to exit if it fails
-        window.update_with_buffer(&buffer, WIDTH, HEIGHT).unwrap();
+        window.update();
+        window.update_buffer(&buffer, WIDTH, HEIGHT).unwrap();
     }
 }
 

--- a/examples/menu.rs
+++ b/examples/menu.rs
@@ -111,6 +111,7 @@ fn main() {
         });
 
         // We unwrap here as we want this code to exit if it fails
-        window.update_with_buffer(&buffer, WIDTH, HEIGHT).unwrap();
+        window.update();
+        window.update_buffer(&buffer, WIDTH, HEIGHT).unwrap();
     }
 }

--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -59,8 +59,9 @@ fn main() {
         });
 
         // We unwrap here as we want this code to exit if it fails
+        window.update();
         window
-            .update_with_buffer(&buffer, width / 2, height / 2)
+            .update_buffer(&buffer, width / 2, height / 2)
             .unwrap();
     }
 }

--- a/examples/multi.rs
+++ b/examples/multi.rs
@@ -32,8 +32,12 @@ fn main() {
         && !orig.is_key_down(Key::Escape)
         && !double.is_key_down(Key::Escape)
     {
-        orig.update_with_buffer(&buffer, width, height).unwrap();
-        double.update_with_buffer(&buffer, width, height).unwrap();
+        orig.update();
+        orig.update_buffer(&buffer, width, height).unwrap();
+
+        double.update();
+        double.update_buffer(&buffer, width, height).unwrap();
+
         pos += 7;
         pos *= 13;
         pos %= buffer.len();

--- a/examples/noise.rs
+++ b/examples/noise.rs
@@ -66,8 +66,9 @@ fn main() {
             }
         });
 
+        window.update();
         window
-            .update_with_buffer(&buffer, new_size.0, new_size.1)
+            .update_buffer(&buffer, new_size.0, new_size.1)
             .unwrap();
     }
 }

--- a/examples/title_cursor.rs
+++ b/examples/title_cursor.rs
@@ -128,6 +128,7 @@ fn main() {
         }
 
         // We unwrap here as we want this code to exit if it fails
-        window.update_with_buffer(&buffer, WIDTH, HEIGHT).unwrap();
+        window.update();
+        window.update_buffer(&buffer, WIDTH, HEIGHT).unwrap();
     }
 }

--- a/examples/transparent.rs
+++ b/examples/transparent.rs
@@ -19,6 +19,7 @@ fn main() {
     .expect("Unable to open Window");
 
     while window.is_open() && !window.is_key_down(Key::Escape) {
-        window.update_with_buffer(&buf, 320, 480).unwrap();
+        window.update();
+        window.update_buffer(&buf, 320, 480).unwrap();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,6 +263,9 @@ impl Window {
     ///
     /// Notice that the buffer needs to be at least the size of the created window.
     ///
+    /// This will only update the framebuffer but not the window and input state.
+    /// To update the window state, call `.update()` separatly.
+    ///
     /// # Examples
     ///
     /// ```no_run
@@ -282,18 +285,13 @@ impl Window {
     ///
     /// let mut window = Window::new("Test", window_width, window_height, WindowOptions::default()).unwrap();
     ///
-    /// window.update_with_buffer(&buffer, buffer_width, buffer_height).unwrap();
+    /// window.update(); // Update input state
+    /// window.update_buffer(&buffer, buffer_width, buffer_height).unwrap(); // Update framebuffer
     /// ```
     #[inline]
-    pub fn update_with_buffer(
-        &mut self,
-        buffer: &[u32],
-        width: usize,
-        height: usize,
-    ) -> Result<()> {
-        self.0.update_rate();
+    pub fn update_buffer(&mut self, buffer: &[u32], width: usize, height: usize) -> Result<()> {
         self.0
-            .update_with_buffer_stride(buffer, width, height, width)
+            .update_buffer_with_stride(buffer, width, height, width)
     }
 
     ///

--- a/src/os/macos/mod.rs
+++ b/src/os/macos/mod.rs
@@ -359,15 +359,13 @@ impl Window {
         }
     }
 
-    pub fn update_with_buffer_stride(
+    pub fn update_buffer_with_stride(
         &mut self,
         buffer: &[u32],
         buf_width: usize,
         buf_height: usize,
         buf_stride: usize,
     ) -> Result<()> {
-        self.key_handler.update();
-
         buffer_helper::check_buffer_size(buf_width, buf_height, buf_stride, buffer)?;
 
         unsafe {
@@ -377,13 +375,6 @@ impl Window {
                 buf_width as u32,
                 buf_height as u32,
                 buf_stride as u32,
-            );
-            Self::set_mouse_data(self);
-            mfb_set_key_callback(
-                self.window_handle,
-                mem::transmute(self),
-                key_callback,
-                char_callback,
             );
         }
 

--- a/src/os/redox/mod.rs
+++ b/src/os/redox/mod.rs
@@ -100,22 +100,16 @@ impl Window {
         0 as *mut raw::c_void
     }
 
-    pub fn update_with_buffer(&mut self, buffer: &[u32]) -> Result<()> {
-        self.process_events();
-        self.key_handler.update();
-
-        let check_res = buffer_helper::check_buffer_size(
-            self.buffer_width,
-            self.buffer_height,
-            self.window_scale,
-            buffer,
-        );
-        if check_res.is_err() {
-            return check_res;
-        }
+    pub fn update_buffer_with_stride(
+        &mut self,
+        buffer: &[u32],
+        buf_width: usize,
+        buf_height: usize,
+        buf_stride: usize,
+    ) -> Result<()> {
+        buffer_helper::check_buffer_size(buf_width, buf_height, buf_stride, buffer)?;
 
         self.render_buffer(buffer);
-        self.window.sync();
 
         Ok(())
     }

--- a/src/os/unix/mod.rs
+++ b/src/os/unix/mod.rs
@@ -65,7 +65,7 @@ impl Window {
         }
     }
 
-    pub fn update_with_buffer_stride(
+    pub fn update_buffer_with_stride(
         &mut self,
         buffer: &[u32],
         buf_width: usize,
@@ -75,11 +75,11 @@ impl Window {
         match *self {
             #[cfg(feature = "x11")]
             Window::X11(ref mut w) => {
-                w.update_with_buffer_stride(buffer, buf_width, buf_height, buf_stride)
+                w.update_buffer_with_stride(buffer, buf_width, buf_height, buf_stride)
             }
             #[cfg(feature = "wayland")]
             Window::Wayland(ref mut w) => {
-                w.update_with_buffer_stride(buffer, buf_width, buf_height, buf_stride)
+                w.update_buffer_with_stride(buffer, buf_width, buf_height, buf_stride)
             }
         }
     }

--- a/src/os/unix/wayland.rs
+++ b/src/os/unix/wayland.rs
@@ -1087,7 +1087,7 @@ impl Window {
         }
     }
 
-    pub fn update_with_buffer_stride(
+    pub fn update_buffer_with_stride(
         &mut self,
         buffer: &[u32],
         buf_width: usize,
@@ -1101,7 +1101,6 @@ impl Window {
         self.display
             .update_framebuffer(&self.buffer[..], (self.width as i32, self.height as i32))
             .map_err(|e| Error::UpdateFailed(format!("Error updating framebuffer: {:?}", e)))?;
-        self.update();
 
         Ok(())
     }

--- a/src/os/unix/x11.rs
+++ b/src/os/unix/x11.rs
@@ -528,7 +528,7 @@ impl Window {
         };
     }
 
-    pub fn update_with_buffer_stride(
+    pub fn update_buffer_with_stride(
         &mut self,
         buffer: &[u32],
         buf_width: usize,
@@ -538,8 +538,6 @@ impl Window {
         buffer_helper::check_buffer_size(buf_width, buf_height, buf_stride, buffer)?;
 
         unsafe { self.raw_blit_buffer(buffer, buf_width, buf_height, buf_stride) };
-
-        self.update();
 
         Ok(())
     }

--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -803,7 +803,7 @@ impl Window {
         }
     }
 
-    pub fn update_with_buffer_stride(
+    pub fn update_buffer_with_stride(
         &mut self,
         buffer: &[u32],
         buf_width: usize,
@@ -811,8 +811,6 @@ impl Window {
         buf_stride: usize,
     ) -> Result<()> {
         let window = self.window.unwrap();
-
-        Self::generic_update(self, window);
 
         buffer_helper::check_buffer_size(buf_width, buf_height, buf_stride, buffer)?;
 
@@ -825,8 +823,6 @@ impl Window {
         unsafe {
             winuser::InvalidateRect(window, ptr::null_mut(), minwindef::TRUE);
         }
-
-        Self::message_loop(self, window);
 
         Ok(())
     }


### PR DESCRIPTION
Hi,
I basically needed a way to update the framebuffer independently of input due to blocking and expense of updating the input state.

I had this branch laying around for some time now, I rebased & updated the changes so the branch can be merged, before it completely code-rots.  Although very specialized, I'd like to get this upstream.

Tested only on Linux/X11, but all the code is basically a copy of `update_with_buffer_stride` with any input updates ripped out.

I'm open for suggestions and be willing to further work on this if needed in order to get this merged.