### PR TITLE
Support topmost functionality in Windows

### DIFF
--- a/examples/topmost.rs
+++ b/examples/topmost.rs
@@ -1,0 +1,23 @@
+use minifb::{Key, ScaleMode, Window, WindowOptions};
+
+fn main() {
+    // Allocate the output buffer.
+    let buf = vec![0x00FFFF00; 320 * 480];
+
+    let mut window = Window::new(
+        "Press ESC to exit",
+        320,
+        480,
+        WindowOptions {
+            resize: true,
+            scale_mode: ScaleMode::Center,
+            topmost: true,
+            ..WindowOptions::default()
+        },
+    )
+    .expect("Unable to open Window");
+
+    while window.is_open() && !window.is_key_down(Key::Escape) {
+        window.update_with_buffer(&buf, 320, 480).unwrap();
+    }
+}

--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -610,6 +610,10 @@ impl Window {
                 },
             };
 
+            if opts.topmost {
+                window.topmost(true)
+            }
+
             Ok(window)
         }
     }
@@ -984,6 +988,25 @@ impl Window {
             let t = self.accel_key;
             self.accel_key = INVALID_ACCEL;
             Some(t)
+        }
+    }
+
+    #[inline]
+    fn topmost(&self, topmost: bool) {
+        unsafe {
+            winuser::SetWindowPos(
+                self.window.unwrap(),
+                if topmost == true {
+                    winuser::HWND_TOPMOST
+                } else {
+                    winuser::HWND_TOP
+                },
+                0,
+                0,
+                0,
+                0,
+                winuser::SWP_SHOWWINDOW | winuser::SWP_NOSIZE | winuser::SWP_NOMOVE,
+            );
         }
     }
 }


### PR DESCRIPTION
Most of this was taken from #159. This does not include the API addition of adding a topmost call on Window.

That should probably be in another PR. And the doc fixes as well.

Used implementation from https://github.com/emoon/rust_minifb/pull/159#discussion_r401374050

Co-authored-by: phillvancejr <phillipvancejr@gmail.com>
Co-authored-by: Daniel Collin <daniel@collin.com>