### PR TITLE
Windows: Fix mouse positions not honoring MouseMode

### DIFF
--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -680,16 +680,15 @@ impl Window {
         let h = self.height as f32;
 
         // TODO: Needs to be fixed with resize support
-        mouse_handler::get_pos(mode, self.mouse.x, self.mouse.y, s, w * s, h * s)
+        mouse_handler::get_pos(mode, self.mouse.x, self.mouse.y, s, w, h)
     }
 
     pub fn get_unscaled_mouse_pos(&self, mode: MouseMode) -> Option<(f32, f32)> {
-        let s = self.scale_factor as f32;
         let w = self.width as f32;
         let h = self.height as f32;
 
         // TODO: Needs to be fixed with resize support
-        mouse_handler::get_pos(mode, self.mouse.x, self.mouse.y, 1.0, w * s, h * s)
+        mouse_handler::get_pos(mode, self.mouse.x, self.mouse.y, 1.0, w, h)
     }
 
     pub fn get_mouse_down(&self, button: MouseButton) -> bool {


### PR DESCRIPTION
Mouse positions went past the right side and bottom of the window even with discard and clamp mouse modes. This fixed things with the mouse example and seems to match what other backends do.

On a side note, the TODO-comments look stale as I didn't see any odd behavior with resizing after the fix.