### PR TITLE
Fix: winuser | DestroyWindow

### DIFF
--- a/examples/drop.rs
+++ b/examples/drop.rs
@@ -1,0 +1,30 @@
+use std::thread;
+use std::time::{Duration, Instant};
+use minifb::{ Key, ScaleMode, Window, WindowOptions };
+
+const WIDTH:  usize = 640 / 2;
+const HEIGHT: usize = 360 / 2;
+
+fn show_window() {
+    let mut window = Window::new(
+        "Drop Test - Window will close after 2 seconds.",
+        WIDTH,
+        HEIGHT,
+        WindowOptions::default(),
+    )
+    .expect("Unable to create window");
+    
+    let now = Instant::now();
+    
+    while window.is_open() && now.elapsed().as_secs() < 2 {
+        window.update();
+    }
+}
+
+fn main() {
+    println!("Showing Window");
+    show_window();
+    println!("Dropped");
+    thread::sleep(Duration::from_millis(2000));
+    println!("Exiting");
+}

--- a/examples/drop.rs
+++ b/examples/drop.rs
@@ -1,8 +1,8 @@
+use minifb::{Key, ScaleMode, Window, WindowOptions};
 use std::thread;
 use std::time::{Duration, Instant};
-use minifb::{ Key, ScaleMode, Window, WindowOptions };
 
-const WIDTH:  usize = 640 / 2;
+const WIDTH: usize = 640 / 2;
 const HEIGHT: usize = 360 / 2;
 
 fn show_window() {
@@ -13,9 +13,9 @@ fn show_window() {
         WindowOptions::default(),
     )
     .expect("Unable to create window");
-    
+
     let now = Instant::now();
-    
+
     while window.is_open() && now.elapsed().as_secs() < 2 {
         window.update();
     }

--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -1272,7 +1272,7 @@ impl Drop for Window {
             }
 
             if self.window.is_some() {
-                winuser::CloseWindow(self.window.unwrap());
+                winuser::DestroyWindow(self.window.unwrap());
             }
         }
     }


### PR DESCRIPTION
This PR updates the Windows winuser `Drop` implementation to use `winuser::DestroyWindow(...)` instead of `winuser::CloseWindow(...)`. According to the [docs](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-closewindow), `CloseWindow()` "Minimizes (but does not destroy) the specified window.".  This should allow the Window to be properly destroyed once it falls out of scope.

I have also added a small example `cargo run --example drop` that tests the behavior. Feel free to remove this if not needed. Have left it there in case it was helpful to quickly test this behavior across other OS. 