### PR TITLE
Update xkb_keymap reference

### DIFF
--- a/src/os/posix/wayland.rs
+++ b/src/os/posix/wayland.rs
@@ -1055,7 +1055,7 @@ impl Window {
                     let kb_map_ptr = xkbcommon_sys::xkb_keymap_new_from_string(
                         ctx,
                         v.as_ptr() as *const _ as *const std::os::raw::c_char,
-                        xkbcommon_sys::xkb_keymap_format::XKB_KEYMAP_FORMAT_TEXT_v1,
+                        xkbcommon_sys::xkb_keymap_format::XKB_KEYMAP_FORMAT_TEXT_V1,
                         0,
                     );
 


### PR DESCRIPTION
The xkbcommon_sys crate seems to have been updated today, and now the minifb project won't compile. 

We can fix this by updating XKB_KEYMAP_FORMAT_TEXT_v1 to XKB_KEYMAP_FORMAT_TEXT_V1.