### PR TITLE
key_handler: add a callback for key events

### DIFF
--- a/src/key_handler.rs
+++ b/src/key_handler.rs
@@ -30,6 +30,9 @@ impl KeyHandler {
     #[inline]
     pub fn set_key_state(&mut self, key: Key, state: bool) {
         self.keys[key as usize] = state;
+        if let Some(cb) = &mut self.key_callback {
+            cb.set_key_state(key, state);
+        }
     }
 
     pub fn get_keys(&self) -> Option<Vec<Key>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,10 +83,17 @@ pub enum CursorStyle {
     ResizeAll,
 }
 
-/// This trait can be implemented and set with ```set_input_callback``` to reieve a callback
-/// whene there is inputs incoming. Currently only support unicode chars.
+/// This trait can be implemented and set with ```set_input_callback``` to receive a callback
+/// when there is inputs.
 pub trait InputCallback {
+    /// Called when text is added to the window, or a key is pressed. This passes
+    /// in a unicode character, and therefore does not report control characters.
     fn add_char(&mut self, uni_char: u32);
+
+    /// Called whenever a key is pressed or released. This reports the state of the
+    /// key in the `state` argument, as well as the translated key in the `key` argument.
+    /// This includes control characters such as `Key::LeftShift`.
+    fn set_key_state(&mut self, _key: Key, _state: bool) {}
 }
 
 mod error;


### PR DESCRIPTION
Add a callback for key events. This includes complete events such as
Shift, not just text events.

A default handler is provided for backwards compatibility.