### PR TITLE
address clippy lints

### DIFF
--- a/examples/julia.rs
+++ b/examples/julia.rs
@@ -36,7 +36,7 @@ fn main() {
     window.set_background_color(0, 0, 20);
 
     while window.is_open() && !window.is_key_down(Key::Escape) {
-        for i in 0..buffer.len() {
+        for (i, pixel) in buffer.iter_mut().enumerate() {
             let mut real = map((i % WIDTH) as f64, 0., WIDTH as f64, x_min, x_max);
             let mut imag = map((i / HEIGHT) as f64, 0., HEIGHT as f64, y_min, y_max);
 
@@ -55,7 +55,7 @@ fn main() {
                 n += 1;
             }
 
-            buffer[i] = fill(n);
+            *pixel = fill(n);
         }
 
         angle += 0.1;
@@ -71,8 +71,8 @@ fn map(val: f64, start1: f64, stop1: f64, start2: f64, stop2: f64) -> f64 {
 
 fn fill(n: u32) -> u32 {
     if FRACTAL_DEPTH == n {
-        return 0x00;
+        0x00
     } else {
-        return n * 32 % 255;
+        n * 32 % 255
     }
 }

--- a/examples/menu.rs
+++ b/examples/menu.rs
@@ -66,9 +66,9 @@ fn main() {
 
     let menu_handle = window.add_menu(&menu);
 
-    window.get_posix_menus().map(|menus| {
+    if let Some(menus) = window.get_posix_menus() {
         println!("Menus {:?}", menus);
-    });
+    }
 
     let mut color_mul = 1;
 
@@ -79,7 +79,7 @@ fn main() {
             }
         }
 
-        window.is_menu_pressed().map(|menu_id| {
+        if let Some(menu_id) = window.is_menu_pressed() {
             match menu_id {
                 COLOR_0_ID => {
                     color_mul = 0xfe0000;
@@ -98,7 +98,7 @@ fn main() {
             }
 
             println!("Menu id {} pressed", menu_id);
-        });
+        }
 
         window.get_keys().iter().for_each(|key| match key {
             Key::W => println!("holding w!"),

--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -42,7 +42,7 @@ fn main() {
             }
         }
 
-        window.get_mouse_pos(MouseMode::Discard).map(|(x, y)| {
+        if let Some((x, y)) = window.get_mouse_pos(MouseMode::Discard) {
             let screen_pos = ((y as usize) * (width / 2)) + x as usize;
 
             if window.get_mouse_down(MouseButton::Left) {
@@ -52,11 +52,11 @@ fn main() {
             if window.get_mouse_down(MouseButton::Right) {
                 buffer[screen_pos] = 0;
             }
-        });
+        }
 
-        window.get_scroll_wheel().map(|scroll| {
+        if let Some(scroll) = window.get_scroll_wheel() {
             println!("Scrolling {} - {}", scroll.0, scroll.1);
-        });
+        }
 
         // We unwrap here as we want this code to exit if it fails
         window

--- a/examples/title_cursor.rs
+++ b/examples/title_cursor.rs
@@ -19,11 +19,7 @@ impl Rect {
         let xe = self.x + self.width;
         let ye = self.y + self.height;
 
-        if (y >= self.y) && (y <= ye) && (x >= self.x) && (x <= xe) {
-            true
-        } else {
-            false
-        }
+        (y >= self.y) && (y <= ye) && (x >= self.x) && (x <= xe)
     }
 }
 

--- a/src/key_handler.rs
+++ b/src/key_handler.rs
@@ -33,17 +33,14 @@ impl KeyHandler {
     }
 
     pub fn get_keys(&self) -> Vec<Key> {
-        let mut index: u16 = 0;
         let mut keys: Vec<Key> = Vec::new();
 
-        for i in self.keys.iter() {
+        for (index, i) in self.keys.iter().enumerate() {
             if *i {
                 unsafe {
                     keys.push(mem::transmute(index as u8));
                 }
             }
-
-            index += 1;
         }
 
         keys
@@ -74,10 +71,9 @@ impl KeyHandler {
     }
 
     pub fn get_keys_pressed(&self, repeat: KeyRepeat) -> Vec<Key> {
-        let mut index: u16 = 0;
         let mut keys: Vec<Key> = Vec::new();
 
-        for i in self.keys.iter() {
+        for (index, i) in self.keys.iter().enumerate() {
             if *i {
                 unsafe {
                     if Self::key_pressed(self, index as usize, repeat) {
@@ -85,8 +81,6 @@ impl KeyHandler {
                     }
                 }
             }
-
-            index += 1;
         }
 
         keys
@@ -108,7 +102,7 @@ impl KeyHandler {
 
     #[inline]
     pub fn is_key_down(&self, key: Key) -> bool {
-        return self.keys[key as usize];
+        self.keys[key as usize]
     }
 
     #[inline]
@@ -139,22 +133,22 @@ impl KeyHandler {
             }
         }
 
-        return false;
+        false
     }
 
     #[inline]
     pub fn is_key_pressed(&self, key: Key, repeat: KeyRepeat) -> bool {
-        return Self::key_pressed(self, key as usize, repeat);
+        Self::key_pressed(self, key as usize, repeat)
     }
 
     #[inline]
     pub fn is_key_released(&self, key: Key) -> bool {
         let idx = key as usize;
-        return self.is_key_index_released(idx);
+        self.is_key_index_released(idx)
     }
 
     #[inline]
     fn is_key_index_released(&self, idx: usize) -> bool {
-        return self.keys_prev[idx] && !self.keys[idx];
+        self.keys_prev[idx] && !self.keys[idx]
     }
 }

--- a/src/os/posix/common.rs
+++ b/src/os/posix/common.rs
@@ -51,8 +51,6 @@ impl Menu {
     }
 
     pub fn remove_item(&mut self, handle: &MenuItemHandle) {
-        self.internal
-            .items
-            .retain(|ref item| item.handle.0 != handle.0);
+        self.internal.items.retain(|item| item.handle.0 != handle.0);
     }
 }

--- a/src/os/posix/mod.rs
+++ b/src/os/posix/mod.rs
@@ -22,6 +22,7 @@ pub use common::Menu;
 use std::os::raw;
 
 // Differentiate between Wayland and X11 at run-time
+#[allow(clippy::large_enum_variant)]
 pub enum Window {
     #[cfg(feature = "x11")]
     X11(x11::Window),
@@ -131,7 +132,6 @@ impl Window {
 
     pub fn topmost(&self, _topmost: bool) {
         // We will just do nothing until it is implemented so that nothing breaks
-        ()
     }
 
     pub fn get_size(&self) -> (usize, usize) {

--- a/src/os/posix/wayland.rs
+++ b/src/os/posix/wayland.rs
@@ -260,7 +260,7 @@ impl DisplayInfo {
             )
         };
         tempfile
-            .write_all(&slice[..])
+            .write_all(slice)
             .map_err(|e| Error::WindowCreate(format!("Io Error: {:?}", e)))?;
         tempfile
             .flush()
@@ -311,7 +311,7 @@ impl DisplayInfo {
             .map_err(|e| Error::WindowCreate(format!("Roundtrip failed: {:?}", e)))?;
 
         // Give the buffer to the surface and commit
-        surface.attach(Some(&buffer), 0, 0);
+        surface.attach(Some(buffer), 0, 0);
         surface.damage(0, 0, i32::max_value(), i32::max_value());
         surface.commit();
 
@@ -386,7 +386,7 @@ impl DisplayInfo {
             )
         };
 
-        fd.write_all(&slice[..])?;
+        fd.write_all(slice)?;
         fd.flush()?;
 
         // Acknowledge the last configure event
@@ -701,7 +701,7 @@ impl Window {
     }
 
     pub fn remove_menu(&mut self, handle: MenuHandle) {
-        self.menus.retain(|ref menu| menu.handle != handle);
+        self.menus.retain(|menu| menu.handle != handle);
     }
 
     pub fn is_menu_pressed(&mut self) -> Option<usize> {

--- a/src/os/posix/x11.rs
+++ b/src/os/posix/x11.rs
@@ -176,7 +176,7 @@ impl DisplayInfo {
                 _context: context,
                 cursor_lib,
                 // the following are determined later...
-                cursors: [0 as xlib::Cursor; 8],
+                cursors: [0; 8],
                 keyb_ext: false,
                 wm_delete_window: 0,
             })
@@ -397,8 +397,8 @@ impl Window {
             let xim = (d.lib.XOpenIM)(
                 d.display,
                 0 as XrmDatabase,
-                0 as *mut c_char,
-                0 as *mut c_char,
+                ptr::null_mut::<c_char>(),
+                ptr::null_mut::<c_char>(),
             );
             if (xim as usize) == 0 {
                 return Err(Error::WindowCreate(
@@ -569,7 +569,6 @@ impl Window {
         match CString::new(title) {
             Err(_) => {
                 println!("Unable to convert {} to c_string", title);
-                return;
             }
 
             Ok(t) => unsafe {
@@ -830,7 +829,7 @@ impl Window {
     }
 
     pub fn remove_menu(&mut self, handle: MenuHandle) {
-        self.menus.retain(|ref menu| menu.handle != handle);
+        self.menus.retain(|menu| menu.handle != handle);
     }
 
     pub fn is_menu_pressed(&mut self) -> Option<usize> {


### PR DESCRIPTION
Fix the clippy warnings that appear when running `cargo clippy` on linux. There may be other warnings on windows and/or macos.