### PR TITLE
Revert bump of `xkbcommon-sys`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ wayland-protocols = { version = "0.29", features = ["client", "unstable_protocol
 wayland-cursor = {version = "0.29", optional = true}
 tempfile = {version = "3.2", optional = true}
 xkb = {version = "0.2.1", optional = true}
-xkbcommon-sys = {version = "1.3", optional = true}
+xkbcommon-sys = {version = "0.7.5", optional = true}
 x11-dl = {version = "2.19.1", optional = true}
 libc = {version = "0.2.107", optional = true}
 

--- a/src/os/posix/wayland.rs
+++ b/src/os/posix/wayland.rs
@@ -1072,14 +1072,12 @@ impl Window {
                     v.set_len(len as usize);
                     file.read_exact(&mut v)?;
 
-                    let ctx = xkbcommon_sys::xkb_context_new(
-                        xkbcommon_sys::xkb_context_flags::XKB_CONTEXT_NO_FLAGS,
-                    );
+                    let ctx = xkbcommon_sys::xkb_context_new(0);
                     let kb_map_ptr = xkbcommon_sys::xkb_keymap_new_from_string(
                         ctx,
                         v.as_ptr() as *const _ as *const std::os::raw::c_char,
                         xkbcommon_sys::xkb_keymap_format::XKB_KEYMAP_FORMAT_TEXT_V1,
-                        xkbcommon_sys::xkb_keymap_compile_flags::XKB_KEYMAP_COMPILE_NO_FLAGS,
+                        0,
                     );
 
                     // Wrap keymap


### PR DESCRIPTION
We I created the previous PR to update versions I didn't realize that `xkb` still depends on the previous version.
Also there are some issues in the new version: https://github.com/meh/rust-xkbcommon-sys/issues/7