### PR TITLE
Add getter for window position.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,6 +359,24 @@ impl Window {
     }
 
     ///
+    /// Gets the position of the window. This is useful if you want
+    /// to store the position of the window across sessions
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use minifb::*;
+    /// # let mut window = Window::new("Test", 640, 400, WindowOptions::default()).unwrap();
+    /// // Retrieves the current window position
+    /// let (x,y) = window.get_position();
+    /// ```
+    ///
+    #[inline]
+    pub fn get_position(&self) -> (isize, isize) {
+        self.0.get_position()
+    }
+
+    ///
     /// Makes the window the topmost window and makes it stay always on top. This is useful if you
     /// want the window to float above all over windows
     ///

--- a/src/native/macosx/MacMiniFB.m
+++ b/src/native/macosx/MacMiniFB.m
@@ -559,6 +559,23 @@ void mfb_set_position(void* window, int x, int y)
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+void mfb_get_position(const void* window, int *px, int *py)
+{
+	OSXWindow* win = (OSXWindow*)window;
+	const NSRect rectW = [win frame];
+	if( px != NULL ) {
+		*px = rectW.origin.x;
+	}
+	if( py != NULL ) {
+		const NSRect msf = [[NSScreen mainScreen] frame];
+		const float height = msf.size.height;
+		const float h = rectW.size.height;
+		*py = height - ( rectW.origin.y + h ); // origin is from bottom
+	}
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 int mfb_should_close(void* window)
 {
 	OSXWindow* win = (OSXWindow*)window;

--- a/src/os/macos/mod.rs
+++ b/src/os/macos/mod.rs
@@ -174,6 +174,7 @@ extern "C" {
         buf_stride: u32,
     );
     fn mfb_set_position(window: *mut c_void, x: i32, y: i32);
+    fn mfb_get_position(window: *const c_void, x: *mut i32, y: *mut i32);
     fn mfb_set_key_callback(
         window: *mut c_void,
         target: *mut c_void,
@@ -406,6 +407,15 @@ impl Window {
     #[inline]
     pub fn set_position(&mut self, x: isize, y: isize) {
         unsafe { mfb_set_position(self.window_handle, x as i32, y as i32) }
+    }
+
+    #[inline]
+    pub fn get_position(&self) -> (isize, isize) {
+        let (mut x, mut y) = (0, 0);
+        unsafe {
+            mfb_get_position(self.window_handle, &mut x, &mut y);
+        }
+        (x as isize, y as isize)
     }
 
     #[inline]

--- a/src/os/posix/mod.rs
+++ b/src/os/posix/mod.rs
@@ -130,6 +130,15 @@ impl Window {
         }
     }
 
+    pub fn get_position(&self) -> (isize, isize) {
+        match *self {
+            #[cfg(feature = "x11")]
+            Window::X11(ref w) => w.get_position(),
+            #[cfg(feature = "wayland")]
+            Window::Wayland(ref w) => w.get_position(),
+        }
+    }
+
     pub fn topmost(&self, _topmost: bool) {
         // We will just do nothing until it is implemented so that nothing breaks
     }

--- a/src/os/posix/wayland.rs
+++ b/src/os/posix/wayland.rs
@@ -651,7 +651,7 @@ impl Window {
         let (mut x, mut y) = (0, 0);
 
         unsafe {
-            todo!("get_position");
+            //            todo!("get_position");
         }
 
         (x as isize, y as isize)

--- a/src/os/posix/wayland.rs
+++ b/src/os/posix/wayland.rs
@@ -647,6 +647,16 @@ impl Window {
             .set_geometry((x as i32, y as i32), (self.width, self.height));
     }
 
+    pub fn get_position(&self) -> (isize, isize) {
+        let (mut x, mut y) = (0, 0);
+
+        unsafe {
+            todo!("get_position");
+        }
+
+        (x as isize, y as isize)
+    }
+
     pub fn set_rate(&mut self, rate: Option<Duration>) {
         self.update_rate.set_rate(rate);
     }

--- a/src/os/posix/x11.rs
+++ b/src/os/posix/x11.rs
@@ -658,6 +658,17 @@ impl Window {
     }
 
     #[inline]
+    pub fn get_position(&self) -> (isize, isize) {
+        let (mut x, mut y) = (0, 0);
+
+        unsafe {
+            todo!("get_position");
+        }
+
+        (x as isize, y as isize)
+    }
+
+    #[inline]
     pub fn get_size(&self) -> (usize, usize) {
         (self.width as usize, self.height as usize)
     }

--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -646,6 +646,25 @@ impl Window {
     }
 
     #[inline]
+    pub fn get_position(&self) -> (isize, isize) {
+        let (mut x, mut y) = (0, 0);
+
+        unsafe {
+            let mut rect = windef::RECT {
+                left: 0,
+                right: 0,
+                top: 0,
+                bottom: 0,
+            };
+            if winuser::GetWindowRect(self.window.unwrap(), &mut rect) != 0 {
+                x = rect.left;
+                y = rect.top;
+            }
+        }
+        (x as isize, y as isize)
+    }
+
+    #[inline]
     pub fn topmost(&self, topmost: bool) {
         unsafe {
             winuser::SetWindowPos(


### PR DESCRIPTION
For a current project I wanted to store the layout of windows on the screen to reuse for the next session.

I added `get_position` to the window.
It is tested on macos, and windows - with a single display connected.
I created a stub for linux, which always returns 0,0. It compiles, but is untested due to lack of a system to test on.

It will need some rework for multi display systems, but I don't have one to do that.
I tried to keep the formatting, and style in line with the original.
