### PR TITLE
Add fileapi feature gate of winapi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,8 @@ features = [
     "winuser",
     "wingdi",
     "libloaderapi",
-    "errhandlingapi"
+    "errhandlingapi",
+    "fileapi"
 ]
 
 [features]


### PR DESCRIPTION
When building some apps, it throws an error at  `winapi::um::fileapi::GetFullPathNameW` as "could not find `fileapi` in `um`". This PR fixes the error.