### PR TITLE
Use coercion on types failing compilation on 64 bit raspbian bullseye

### DIFF
--- a/src/os/posix/wayland.rs
+++ b/src/os/posix/wayland.rs
@@ -1089,7 +1089,7 @@ impl Window {
                     let ctx = xkbcommon_sys::xkb_context_new(0);
                     let kb_map_ptr = xkbcommon_sys::xkb_keymap_new_from_string(
                         ctx,
-                        addr as *const i8,
+                        addr as _,
                         xkbcommon_sys::xkb_keymap_format::XKB_KEYMAP_FORMAT_TEXT_V1,
                         0,
                     );

--- a/src/os/posix/x11.rs
+++ b/src/os/posix/x11.rs
@@ -397,7 +397,7 @@ impl Window {
             );
 
             let empty_string = b"\0";
-            (d.lib.XSetLocaleModifiers)(empty_string.as_ptr() as *const i8);
+            (d.lib.XSetLocaleModifiers)(empty_string.as_ptr() as _);
 
             let xim = (d.lib.XOpenIM)(
                 d.display,
@@ -614,8 +614,8 @@ impl Window {
     #[inline]
     pub fn set_icon(&mut self, icon: Icon) {
         // XChangeProperty
-        let net_string_ptr = b"_NET_WM_ICON\0".as_ptr() as *const i8;
-        let cardinal_ptr = b"CARDINAL\0".as_ptr() as *const i8;
+        let net_string_ptr = b"_NET_WM_ICON\0".as_ptr() as _;
+        let cardinal_ptr = b"CARDINAL\0".as_ptr() as _;
 
         unsafe {
             if let Icon::Buffer(ptr, len) = icon {


### PR DESCRIPTION
This addresses #291 where compilation failed on a Raspberry Pi with mismatched types errors.