### PR TITLE
[X11] Fix window names not supporting UTF-8

### DIFF
--- a/src/os/posix/x11.rs
+++ b/src/os/posix/x11.rs
@@ -440,6 +440,22 @@ impl Window {
             }
 
             (d.lib.XStoreName)(d.display, handle, name.as_ptr());
+            if let Ok(name_len) = c_int::try_from(name.to_bytes().len()) {
+                let net_wm_name = d.intern_atom("_NET_WM_NAME", false);
+                let utf8_string = d.intern_atom("UTF8_STRING", false);
+                (d.lib.XChangeProperty)(
+                    d.display,
+                    handle,
+                    net_wm_name,
+                    utf8_string,
+                    8,
+                    xlib::PropModeReplace,
+                    name.as_ptr() as *const c_uchar,
+                    name_len,
+                );
+            } else {
+                return Err(Error::WindowCreate("Window name too long".to_owned()));
+            }
 
             (d.lib.XSelectInput)(
                 d.display,


### PR DESCRIPTION
Currently, UTF-8 characters don't render correctly in window titles (c.f. screenshots below). This is likely due to the fact that the X11 driver only uses `XStoreName`, which sets a name in a way that's not really intended for the user to see. This PR fixes that, making it possible to use UTF-8 characters (I tested diacritics and emojis) in the window title.

### How ?

In addition to the existing `XStoreName` call, I also call [`XChangeProperty`](https://linux.die.net/man/3/xchangeproperty) to set the [`_NET_WM_NAME`/`UTF8_STRING`](https://specifications.freedesktop.org/wm-spec/1.3/ar01s05.html) property. This adds one possible point of failure: `XChangeProperty` takes an `int nelements` as its last parameter, and the actual length of the string could be bigger than what a `c_int` can store. In the unlikely event that this happens, a specific error message is returned.

### Screenshots (context: I replaced a dash `-` with an em dash `—` in the fractal example)

Before:
![fractal](https://user-images.githubusercontent.com/46636609/167134511-db23d575-e818-4b4a-ae40-5ef51c0178cc.png)
After:
![fractal2](https://user-images.githubusercontent.com/46636609/167134517-4137351e-9001-4439-99cd-af32406cd385.png)

---

Feel free to ask me to change a few things if needed, this PR is spontaneous, and I've never got to discuss the issue before.