### PR TITLE
ARM and AARCH64 Windows Support

### DIFF
--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -151,6 +151,8 @@ fn char_down(window: &mut Window, code_point: u32) {
     }
 }
 
+
+
 #[cfg(target_arch = "x86_64")]
 unsafe fn set_window_long(window: windef::HWND, data: basetsd::LONG_PTR) -> basetsd::LONG_PTR {
     winuser::SetWindowLongPtrW(window, winuser::GWLP_USERDATA, data)
@@ -169,6 +171,25 @@ unsafe fn set_window_long(window: windef::HWND, data: ntdef::LONG) -> ntdef::LON
 #[cfg(target_arch = "x86")]
 unsafe fn get_window_long(window: windef::HWND) -> ntdef::LONG {
     winuser::GetWindowLongW(window, winuser::GWLP_USERDATA)
+}
+#[cfg(target_arch = "aarch64")]
+unsafe fn set_window_long(window: windef::HWND, data: basetsd::LONG_PTR) -> basetsd::LONG_PTR {
+    winuser::SetWindowLongPtrW(window, winuser::GWLP_USERDATA, data)
+}
+
+#[cfg(target_arch = "aarch64")]
+unsafe fn get_window_long(window: windef::HWND) -> basetsd::LONG_PTR {
+    winuser::GetWindowLongPtrW(window, winuser::GWLP_USERDATA)
+}
+
+#[cfg(target_arch = "arm")]
+unsafe fn set_window_long(window: windef::HWND, data: basetsd::LONG_PTR) -> basetsd::LONG_PTR {
+    winuser::SetWindowLongPtrW(window, winuser::GWLP_USERDATA, data)
+}
+
+#[cfg(target_arch = "arm")]
+unsafe fn get_window_long(window: windef::HWND) -> basetsd::LONG_PTR {
+    winuser::GetWindowLongPtrW(window, winuser::GWLP_USERDATA)
 }
 
 unsafe extern "system" fn wnd_proc(

--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -151,8 +151,6 @@ fn char_down(window: &mut Window, code_point: u32) {
     }
 }
 
-
-
 #[cfg(target_arch = "x86_64")]
 unsafe fn set_window_long(window: windef::HWND, data: basetsd::LONG_PTR) -> basetsd::LONG_PTR {
     winuser::SetWindowLongPtrW(window, winuser::GWLP_USERDATA, data)


### PR DESCRIPTION
Things were not compiling for my ARM64 Windows 11 machine. With this simple addition it works again.