### PR TITLE
set byposition flag when removing menus on windows

### DIFF
--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -1087,7 +1087,11 @@ impl Window {
         for i in 0..self.menus.len() {
             if self.menus[i].menu_handle == handle.0 as windef::HMENU {
                 unsafe {
-                    let _t = winuser::RemoveMenu(main_menu, i as minwindef::UINT, 0);
+                    let _t = winuser::RemoveMenu(
+                        main_menu,
+                        i as minwindef::UINT,
+                        winuser::MF_BYPOSITION,
+                    );
                     winuser::DrawMenuBar(self.window.unwrap());
                 }
                 self.menus.swap_remove(i);


### PR DESCRIPTION
I Could not get menus to be removed on windows, even when running the example.
Looking at the code, it looks like there is a flag missing as per https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-removemenu#parameters.

![image](https://user-images.githubusercontent.com/807383/209538374-928af7f2-6124-4f55-85d9-9d0ece2b6034.png)

This PR simply adds the "By Position" flag that indicates that the menus should be removed by position, not by ID (which is what the `for i in 0..self.menus.len()` seem to indicate is the case).