### PR TITLE
Fix compilation of minifb's X11 binding for 32-bit

### DIFF
--- a/src/os/posix/x11.rs
+++ b/src/os/posix/x11.rs
@@ -724,7 +724,7 @@ impl Window {
                 y,
                 &mut nx,
                 &mut ny,
-                dummy_window.as_mut_ptr() as *mut u64,
+                dummy_window.as_mut_ptr() as *mut c_ulong,
             );
         }
 


### PR DESCRIPTION
FFI signature of `x11::xlib::XTranslateCoordinates` expects a `*mut c_ulong`.
Changing the cast to that  instead of `*mut u64` makes this compile on 32-bit
systems.

I can also confirm that the various examples run fine inside an arm32v7
docker image via X11.