### PR TITLE
X11: Fix changing window title, fixes #322

### DIFF
--- a/examples/title_cursor.rs
+++ b/examples/title_cursor.rs
@@ -111,8 +111,6 @@ fn main() {
         },
     ];
 
-    window.set_title("Different cursor on each color region");
-
     while window.is_open() && !window.is_key_down(Key::Escape) {
         let (mx, my) = window.get_mouse_pos(MouseMode::Clamp).unwrap();
 
@@ -120,6 +118,8 @@ fn main() {
             fill_rect(&mut buffer, rect);
             if rect.is_inside(mx, my) {
                 window.set_cursor_style(rect.cursor_style);
+                window.set_title(
+                    &format!("Different cursor on each color region: {:?}", rect.cursor_style));
             }
         }
 

--- a/examples/title_cursor.rs
+++ b/examples/title_cursor.rs
@@ -118,8 +118,10 @@ fn main() {
             fill_rect(&mut buffer, rect);
             if rect.is_inside(mx, my) {
                 window.set_cursor_style(rect.cursor_style);
-                window.set_title(
-                    &format!("Different cursor on each color region: {:?}", rect.cursor_style));
+                window.set_title(&format!(
+                    "Different cursor on each color region: {:?}",
+                    rect.cursor_style
+                ));
             }
         }
 

--- a/src/os/posix/x11.rs
+++ b/src/os/posix/x11.rs
@@ -577,7 +577,7 @@ impl Window {
     unsafe fn set_title_raw(
         d: &mut DisplayInfo,
         handle: xlib::Window,
-        name: &CStr
+        name: &CStr,
     ) -> core::result::Result<(), String> {
         (d.lib.XStoreName)(d.display, handle, name.as_ptr());
         if let Ok(name_len) = c_int::try_from(name.to_bytes().len()) {


### PR DESCRIPTION
A new private function Window::set_title_raw added so it can be called from both places where the window title is being changed.

Added a dynamic window title changing to title_cursor example for "visual testing" the issue.
