### PR TITLE
Fix disabling menu items on macOS

### DIFF
--- a/src/native/macosx/MacMiniFB.m
+++ b/src/native/macosx/MacMiniFB.m
@@ -840,6 +840,8 @@ uint64_t mfb_add_menu_item(
 void mfb_add_sub_menu(void* parent_menu, const char* menu_name, void* attach_menu) {
 	NSMenu* parent = (NSMenu*)parent_menu;
 	NSMenu* attach = (NSMenu*)attach_menu;
+	[attach setAutoenablesItems:NO];
+	
 	NSString* name = [NSString stringWithUTF8String: menu_name];
 
 	NSMenuItem* newItem = [[NSMenuItem alloc] initWithTitle:name action:NULL keyEquivalent:@""];
@@ -885,6 +887,7 @@ uint64_t mfb_add_menu(void* window, void* m)
 	NSMenu* menu = (NSMenu*)m;
 
  	NSMenu* main_menu = [NSApp mainMenu];
+	[menu setAutoenablesItems:NO];
 
     NSMenuItem* windowMenuItem = [main_menu addItemWithTitle:@"" action:NULL keyEquivalent:@""];
     [NSApp setWindowsMenu:menu];


### PR DESCRIPTION
If a `NSMenu` does not have `setAutoenablesItems:NO` then any `NSMenuItem`s cannot be disabled. This fixes the functionality of disabling menu items on macOS.

Realistically down the line a test case should be added to the `menu` example for disabled menus, but it's not a huge concern and I'm not putting it in this PR.

I've tested this PR with the menu example which has no change (good!) and a personal project which is working as expected. This does not impact menu items that are enabled by default through minifb.