### PR TITLE
Improved smoothness of updating the window

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -382,9 +382,11 @@ impl Window {
         width: usize,
         height: usize,
     ) -> Result<()> {
+        let update_result = self
+            .0
+            .update_with_buffer_stride(buffer, width, height, width);
         self.0.update_rate();
-        self.0
-            .update_with_buffer_stride(buffer, width, height, width)
+        update_result
     }
 
     /// Updates the window (this is required to call in order to get keyboard/mouse input, etc)
@@ -404,8 +406,8 @@ impl Window {
     /// ```
     #[inline]
     pub fn update(&mut self) {
+        self.0.update();
         self.0.update_rate();
-        self.0.update()
     }
 
     /// Checks if the window is still open. A window can be closed by the user (by for example

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -545,7 +545,7 @@ impl Window {
     /// Is that lots of CPU time will be spent calling system functions to check for new events in a tight loop making the CPU time go up.
     /// Using `set_target_fps` minifb will check how many frames are left to reach the target FPS and if there are any it will sleep for that amount of frames.
     /// This means that if more frames than the target happened (external code taking longer) minifb will not do any waiting at all so there is no loss in CPU performance with this feature.
-    /// By default it's set to 250 FPS. Setting this value to None and no waiting will be done
+    /// By default it's set to 250 FPS. Setting this value to 0 and no waiting will be done
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Calling the update_rate method after updating the window while a target fps has previously been set improves the smoothness and the consistency of the time it takes to update the window.
Previously the window would sleep untill the target update rate was met and then perform the update, potentially going over the limit.
Now the update of the window is processed before waiting, which sleeps for a more accurate amount of time.