### PR TITLE
Make scalar code plain C

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -45,7 +45,7 @@ fn main() {
     } else if !env.contains("windows") && !env.contains("wasm32") {
         // build scalar on non-windows and non-mac
         cc::Build::new()
-            .file("src/native/posix/scalar.cpp")
+            .file("src/native/posix/scalar.c")
             .opt_level(3) // always build with opts for scaler so it's fast in debug also
             .compile("libscalar.a")
     }

--- a/src/native/posix/scalar.c
+++ b/src/native/posix/scalar.c
@@ -1,7 +1,6 @@
 #include <stdint.h>
-#include <stdio.h>
 
-extern "C" void image_resize_linear(
+void image_resize_linear(
     uint32_t* dst,
     const uint32_t dst_width,
     const uint32_t dst_height,
@@ -10,8 +9,8 @@ extern "C" void image_resize_linear(
     const uint32_t src_height,
     const uint32_t src_stride
 ) {
-    const float x_ratio = float(src_width) / float(dst_width);
-    const float y_ratio = float(src_height) / float(dst_height);
+    const float x_ratio = (float)(src_width) / (float)(dst_width);
+    const float y_ratio = (float)(src_height) / (float)(dst_height);
     const int step_x = x_ratio * 1024.0f;
     const int step_y = y_ratio * 1024.0f;
     int fixed_y = 0;
@@ -39,8 +38,8 @@ static void image_resize_linear_stride(
     const uint32_t src_stride,
     const uint32_t stride
 ) {
-    const float x_ratio = float(src_width) / float(dst_width);
-    const float y_ratio = float(src_height) / float(dst_height);
+    const float x_ratio = (float)(src_width) / (float)(dst_width);
+    const float y_ratio = (float)(src_height) / (float)(dst_height);
     const int step_x = x_ratio * 1024.0f;
     const int step_y = y_ratio * 1024.0f;
     const int stride_step = stride - dst_width;
@@ -60,7 +59,7 @@ static void image_resize_linear_stride(
     }
 }
 
-extern "C" void image_resize_linear_aspect_fill(
+void image_resize_linear_aspect_fill(
     uint32_t* dst,
     const uint32_t dst_width,
     const uint32_t dst_height,
@@ -75,11 +74,11 @@ extern "C" void image_resize_linear_aspect_fill(
         dst[i] = bg_clear;
     }
 
-    const float buffer_aspect = float(src_width) / float(src_height);
-    const float win_aspect = float(dst_width) / float(dst_height);
+    const float buffer_aspect = (float)(src_width) / (float)(src_height);
+    const float win_aspect = (float)(dst_width) / (float)(dst_height);
 
     if (buffer_aspect > win_aspect) {
-        const uint32_t new_height = uint32_t(dst_width / buffer_aspect);
+        const uint32_t new_height = (uint32_t)(dst_width / buffer_aspect);
         const int offset = (new_height - dst_height) / -2;
         image_resize_linear(
             dst + (offset * dst_width),
@@ -87,7 +86,7 @@ extern "C" void image_resize_linear_aspect_fill(
             src, src_width, src_height, src_stride
         );
     } else {
-        const uint32_t new_width = uint32_t(dst_height * buffer_aspect);
+        const uint32_t new_width = (uint32_t)(dst_height * buffer_aspect);
         const int offset = (new_width - dst_width) / -2;
         image_resize_linear_stride(
             dst + offset,
@@ -98,7 +97,7 @@ extern "C" void image_resize_linear_aspect_fill(
     }
 }
 
-extern "C" void image_center(
+void image_center(
     uint32_t* dst,
     const uint32_t dst_width,
     const uint32_t dst_height,
@@ -173,7 +172,7 @@ extern "C" void image_center(
     }
 }
 
-extern "C" void image_upper_left(
+void image_upper_left(
     uint32_t* dst,
     const uint32_t dst_width,
     const uint32_t dst_height,


### PR DESCRIPTION
I discovered that minifb uses and compiles non-Rust code for a few use cases, one of which is to make the image scaling functions optimized on Linux in all profiles.
I'm not keen on this approach, as it means that minifb is reliant on a separate compiler to build the project. As an example, I am using minifb for one of my projects, and someone who wanted to run it got a compiler error when compiling it on Linux. They didn't have a C++ compiler installed:
![image](https://github.com/emoon/rust_minifb/assets/13885008/48bf217c-8774-4fc8-b2bd-655e8c619e19)

Ideally, I'd like to not depend on a C/C++ compiler on Linux.

One option is writing the scalar functions in Rust into their own crate, make minifb depend on that crate and ensure the profile for that dependency is always optimized:
```toml
[profile.dev.package.minifb-scalar]
opt-level = 3
```
although that means there is a second crate to be published on crates.io.

Another option is to just not optimize it, and instruct users of minifb to compile it with optimizations on all profiles:
```toml
[profile.dev.package.minifb]
opt-level = 3
```
although that means slower minifb if we want its debug info in our program. (There's also `debug = true` I guess?)

What are your thoughts on this matter?

This discussion aside, I made this PR to remove the need for a C++ compiler to be installed.
In my experience, it is much more likely for a C compiler to be installed on someone's Linux machine. I hope it's a bit useful :)