### PR TITLE
fix image example buffer size calculation

### DIFF
--- a/examples/image.rs
+++ b/examples/image.rs
@@ -9,7 +9,7 @@ fn main() {
     decoder.set_transformations(Transformations::ALPHA);
     let mut reader = decoder.read_info().unwrap();
 
-    let mut buffer = vec![0u32; reader.output_buffer_size()];
+    let mut buffer = vec![0u32; reader.output_buffer_size() / 4];
 
     // View of pixels as individual subpixels (avoids allocating a second pixel buffer).
     let mut u8_buffer = unsafe {


### PR DESCRIPTION
The calculation of the buffer size for a loaded image in the example code currently allocates a `Vec<u32>` that is exactly 4 times longer than needed.
This is due to `png::decoder::Reader::output_buffer_size()` returning the size of the buffer in bytes.
These bytes are later packed to `u32`s, which reduces the needed length of the `u32` buffer to `png::decoder::Reader::output_buffer_size() / 4`