### PR TITLE
Wasm Improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,33 @@ maintenance = { status = "actively-developed" }
 
 [dev-dependencies]
 png = "0.17"
+console_error_panic_hook = "0.1.7"
+web-sys = { version = "0.3.56", features = [
+  "Blob",
+  "CanvasRenderingContext2d",
+  "CssStyleDeclaration",
+  "Document",
+  "Element",
+  "Gamepad",
+  "GamepadButton",
+  "GamepadEvent",
+  "Headers",
+  "HtmlCanvasElement",
+  "HtmlImageElement",
+  "ImageData",
+  "Navigator",
+  "Node",
+  "Request",
+  "RequestInit",
+  "RequestMode",
+  "Response",
+  "Url",
+  "Window",
+  "console",
+  'KeyboardEvent',
+  'MouseEvent',
+] }
+wasm-bindgen = { version = "0.2.79", features = ["serde-serialize"] }
 
 [build-dependencies]
 cc = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ readme = "README.md"
 
 exclude = ["examples/resources/"]
 
+[[example]]
+name = "wasm"
+crate-type = ["cdylib"]
+
 [badges]
 maintenance = { status = "actively-developed" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ wasm-bindgen-futures = "0.4.29"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_derive = "1.0.123"
 futures = "0.3.12"
+console_error_panic_hook = "0.1.7"
 
 # The `web-sys` crate allows you to interact with the various browser APIs,
 # like the DOM.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ features = ["winuser", "wingdi", "libloaderapi", "errhandlingapi", "fileapi"]
 
 [features]
 default = ["wayland", "x11", "dlopen"]
-web = ["wasm-bindgen", "web-sys", "instant/wasm-bindgen", "instant/inaccurate"]
 dlopen = ["wayland-client/dlopen"]
 x11 = ["x11-dl", "libc"]
 wayland = [
@@ -70,13 +69,9 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_derive = "1.0.123"
 futures = "0.3.12"
 console_error_panic_hook = "0.1.7"
-
 # The `web-sys` crate allows you to interact with the various browser APIs,
 # like the DOM.
-[target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
-version = "0.3.56"
-optional = true
-features = [
+web-sys = { version = "0.3.56", features = [
   "Blob",
   "CanvasRenderingContext2d",
   "CssStyleDeclaration",
@@ -100,11 +95,7 @@ features = [
   "console",
   'KeyboardEvent',
   'MouseEvent',
-]
-
+] }
 # The `wasm-bindgen` crate provides the bare minimum functionality needed
 # to interact with JavaScript.
-[target.'cfg(target_arch = "wasm32")'.dependencies.wasm-bindgen]
-version = "0.2.79"
-optional = true
-features = ["serde-serialize"]
+wasm-bindgen = { version = "0.2.79", features = ["serde-serialize"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,43 +62,6 @@ lazy_static = { version = "1.0", optional = true }
 [target.x86_64-unknown-redox.dependencies]
 orbclient = "0.3.20"
 
-# The `wasm-bindgen` crate provides the bare minimum functionality needed
-# to interact with JavaScript.
-[target.'cfg(target_arch = "wasm32")'.dependencies.wasm-bindgen]
-version = "0.2.79"
-optional = true
-features = ["serde-serialize"]
-
-# The `web-sys` crate allows you to interact with the various browser APIs,
-# like the DOM.
-[target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
-version = "0.3.56"
-optional = true
-features = [
-  "console",
-  "Window",
-  "Document",
-  "Navigator",
-  "Element",
-  "Node",
-  "ImageData",
-  "HtmlCanvasElement",
-  "HtmlImageElement",
-  "CanvasRenderingContext2d",
-  "Headers",
-  "Request",
-  "RequestInit",
-  "RequestMode",
-  "Response",
-  "Blob",
-  "Url",
-  "Gamepad",
-  "GamepadButton",
-  "GamepadEvent",
-  'MouseEvent',
-  'KeyboardEvent',
-]
-
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 instant = { version = "0.1.12", features = ["wasm-bindgen", "inaccurate"] }
 js-sys = "0.3.56"
@@ -106,3 +69,41 @@ wasm-bindgen-futures = "0.4.29"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_derive = "1.0.123"
 futures = "0.3.12"
+
+# The `web-sys` crate allows you to interact with the various browser APIs,
+# like the DOM.
+[target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
+version = "0.3.56"
+optional = true
+features = [
+  "Blob",
+  "CanvasRenderingContext2d",
+  "CssStyleDeclaration",
+  "Document",
+  "Element",
+  "Gamepad",
+  "GamepadButton",
+  "GamepadEvent",
+  "Headers",
+  "HtmlCanvasElement",
+  "HtmlImageElement",
+  "ImageData",
+  "Navigator",
+  "Node",
+  "Request",
+  "RequestInit",
+  "RequestMode",
+  "Response",
+  "Url",
+  "Window",
+  "console",
+  'KeyboardEvent',
+  'MouseEvent',
+]
+
+# The `wasm-bindgen` crate provides the bare minimum functionality needed
+# to interact with JavaScript.
+[target.'cfg(target_arch = "wasm32")'.dependencies.wasm-bindgen]
+version = "0.2.79"
+optional = true
+features = ["serde-serialize"]

--- a/examples/wasm.rs
+++ b/examples/wasm.rs
@@ -1,0 +1,58 @@
+// This example produces a wasm module that you can add to a web project, check out
+// https://github.com/dc740/minifb-async-examples to see how to integrate it
+
+use minifb::{Window, WindowOptions};
+use std::{cell::RefCell, panic, rc::Rc};
+use wasm_bindgen::prelude::*;
+
+const WIDTH: usize = 1280;
+const HEIGHT: usize = 720;
+
+fn window() -> web_sys::Window {
+    web_sys::window().expect("no global `window` exists")
+}
+
+fn request_animation_frame(f: &Closure<dyn FnMut()>) {
+    window()
+        .request_animation_frame(f.as_ref().unchecked_ref())
+        .expect("should register `requestAnimationFrame` OK");
+}
+
+#[wasm_bindgen(start)]
+fn main() {
+    panic::set_hook(Box::new(console_error_panic_hook::hook));
+
+    // The id of a DOM element to render the window into
+    let container = "minifb-container";
+
+    let mut window = Window::new(container, WIDTH, HEIGHT, WindowOptions::default())
+        .expect("Unable to create the window");
+
+    let mut buffer = vec![0; WIDTH * HEIGHT];
+
+    // A reference counted pointer to the closure that will update window
+    let f = Rc::new(RefCell::new(None));
+    let g = f.clone();
+    // we update the window here just to reference the buffer
+    // internally. Next calls to .update() will use the same buffer
+    window.update_with_buffer(&buffer, WIDTH, HEIGHT).unwrap();
+
+    // create the closure for updating and rendering the window
+    *g.borrow_mut() = Some(Closure::wrap(Box::new(move || {
+        for pixel in buffer.iter_mut() {
+            *pixel = pixel.wrapping_add(1);
+        }
+
+        // as the buffer is referenced from inside the ImageData, and
+        // we push that to the canvas, so we could call update() and
+        // avoid all this. I don't think it's possible to get artifacts
+        // on the web side, but I definitely see them on the desktop app
+        let _ = window.update_with_buffer(&buffer, WIDTH, HEIGHT);
+
+        // schedule this closure for running again at next frame
+        request_animation_frame(f.borrow().as_ref().unwrap());
+    }) as Box<dyn FnMut() + 'static>));
+
+    // start the animation loop
+    request_animation_frame(g.borrow().as_ref().unwrap());
+}

--- a/src/key_handler.rs
+++ b/src/key_handler.rs
@@ -1,9 +1,9 @@
-#[cfg(feature = "web")]
+#[cfg(target_arch = "wasm32")]
 extern crate instant;
 
-#[cfg(feature = "web")]
+#[cfg(target_arch = "wasm32")]
 use instant::{Duration, Instant};
-#[cfg(not(feature = "web"))]
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::{Duration, Instant};
 
 use crate::{InputCallback, Key, KeyRepeat};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,9 @@ mod rate;
 use raw_window_handle::{DisplayHandle, HandleError, HasDisplayHandle, WindowHandle};
 use std::{ffi::c_void, fmt, time::Duration};
 
+#[cfg(target_arch = "wasm32")]
+use web_sys::HtmlElement;
+
 #[cfg(target_os = "macos")]
 use os::macos as imp;
 #[cfg(any(
@@ -258,6 +261,7 @@ impl WindowOptions {
 }
 
 impl Window {
+    #[cfg(not(target_arch = "wasm32"))]
     /// Opens up a new window
     ///
     /// # Examples
@@ -293,6 +297,56 @@ impl Window {
             ));
         }
         imp::Window::new(name, width, height, opts).map(Window)
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    /// Opens up a new window
+    ///
+    /// # Examples
+    ///
+    /// Open up a window with default settings
+    ///
+    /// ```no_run
+    /// # use minifb::*;
+    /// let document = web_sys::window().unwrap().document().unwrap();
+    /// let body = document.body().unwrap();
+    /// let mut window = match Window::new(body, 640, 400, WindowOptions::default()) {
+    ///    Ok(win) => win,
+    ///    Err(err) => {
+    ///        println!("Unable to create window {}", err);
+    ///        return;
+    ///    }
+    ///};
+    /// ```
+    ///
+    /// Open up a window that is resizeable
+    /// TODO: Enable web canvas resizing
+    ///
+    /// ```no_run
+    /// # use minifb::*;
+    /// let document = web_sys::window().unwrap().document().unwrap();
+    /// let body = document.body().unwrap();
+    /// let mut window = Window::new(body, 640, 400,
+    ///     WindowOptions {
+    ///        resize: true,
+    ///        ..WindowOptions::default()
+    ///  })
+    ///  .expect("Unable to open Window");
+    /// ```
+    pub fn new(
+        container: HtmlElement,
+        width: usize,
+        height: usize,
+        opts: WindowOptions,
+    ) -> Result<Window> {
+        use web_sys::HtmlElement;
+
+        if opts.transparency && !opts.borderless {
+            return Err(Error::WindowCreate(
+                "Window transparency requires the borderless property".to_owned(),
+            ));
+        }
+        imp::Window::new(container, width, height, opts).map(Window)
     }
 
     /// Allows you to set a new title of the window after creation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,8 @@ use raw_window_handle::{DisplayHandle, HandleError, HasDisplayHandle, WindowHand
 use std::{ffi::c_void, fmt, time::Duration};
 
 #[cfg(target_arch = "wasm32")]
+use std::panic;
+#[cfg(target_arch = "wasm32")]
 use web_sys::HtmlElement;
 
 #[cfg(target_os = "macos")]
@@ -339,6 +341,8 @@ impl Window {
         height: usize,
         opts: WindowOptions,
     ) -> Result<Window> {
+        panic::set_hook(Box::new(console_error_panic_hook::hook));
+
         use web_sys::HtmlElement;
 
         if opts.transparency && !opts.borderless {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,14 +336,12 @@ impl Window {
     ///  .expect("Unable to open Window");
     /// ```
     pub fn new(
-        container: HtmlElement,
+        container: &str,
         width: usize,
         height: usize,
         opts: WindowOptions,
     ) -> Result<Window> {
         panic::set_hook(Box::new(console_error_panic_hook::hook));
-
-        use web_sys::HtmlElement;
 
         if opts.transparency && !opts.borderless {
             return Err(Error::WindowCreate(

--- a/src/os/wasm/mod.rs
+++ b/src/os/wasm/mod.rs
@@ -57,8 +57,10 @@ pub struct Window {
 }
 
 impl Window {
+    /// Create a new window
+    /// * `container` - The id of a DOM element to use as a container
     pub fn new(
-        container: HtmlElement,
+        container: &str,
         width: usize,
         height: usize,
         opts: WindowOptions,
@@ -79,6 +81,12 @@ impl Window {
             .create_element("canvas")
             .unwrap()
             .dyn_into::<HtmlCanvasElement>()
+            .unwrap();
+
+        let container = document
+            .get_element_by_id(container)
+            .unwrap()
+            .dyn_into::<HtmlElement>()
             .unwrap();
 
         container.append_child(&canvas).unwrap();

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -1,8 +1,8 @@
-#[cfg(feature = "web")]
+#[cfg(target_arch = "wasm32")]
 extern crate instant;
-#[cfg(feature = "web")]
+#[cfg(target_arch = "wasm32")]
 use instant::{Duration, Instant};
-#[cfg(not(feature = "web"))]
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::{Duration, Instant};
 
 pub struct UpdateRate {


### PR DESCRIPTION
This PR makes some changes to how `Window`s are instantiated on wasm targets

- The `title` parameter in `Window::new()` has been replaced with `container`, which takes an element the canvas should be appended to
   - Allows more control over where and how to embed a minifb canvas in web projects, and still allows the user to change the window title with `set_title`
   - Rustdoc new window example has been updated for wasm32 target
- `set_cursor_visibility` now properly sets the the html canvas cursor style
- `is_active` now checks if the canvas element is focused