### PR TITLE
Fix incorrect deferencing of Windows window handles

### DIFF
--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -515,13 +515,12 @@ pub struct Window {
 impl HasWindowHandle for Window {
     fn window_handle(&self) -> std::result::Result<WindowHandle, HandleError> {
         let raw_hwnd = self.window.unwrap();
-        let hwnd = match NonZeroIsize::new(unsafe { *(raw_hwnd as *const isize) }) {
+        let hwnd = match NonZeroIsize::new(raw_hwnd as isize) {
             Some(hwnd) => hwnd,
             None => unimplemented!("invalid hwnd"),
         };
 
-        let raw_hinstance =
-            unsafe { *(GetWindowLongPtrW(raw_hwnd, GWLP_HINSTANCE) as *const isize) };
+        let raw_hinstance = unsafe { GetWindowLongPtrW(raw_hwnd, GWLP_HINSTANCE) };
         let hinstance = NonZeroIsize::new(raw_hinstance);
 
         let mut handle = Win32WindowHandle::new(hwnd);


### PR DESCRIPTION
* Fixes https://github.com/emoon/rust_minifb/issues/365

Windows handles are pointers by type, but dereferencing these doesn't have any meaning and naturally may just crash (it does ;-)) - if you're lucky this is caught by Rust debug checks complaining about alignment, if you're not it's just a segfault.

Tested this on https://github.com/Wumpf/minifb_wgpu_web_and_desktop (at https://github.com/Wumpf/minifb_wgpu_web_and_desktop/commit/e39be06686b9b8662d27fd4cb0a3787dfaee172d)