### PR TITLE
[wasm] Fix raw handles, delay `getContext` call to be WebGPU compatible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,12 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - if: matrix.os == 'ubuntu-latest'
-      run: sudo apt install libwayland-cursor0 libxkbcommon-dev libwayland-dev
-    - uses: actions/checkout@v2
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - if: matrix.os == 'ubuntu-latest'
+        run: sudo apt install libwayland-cursor0 libxkbcommon-dev libwayland-dev
+      - uses: actions/checkout@v2
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose
+      - name: Check wasm build
+        run: cargo check --target wasm32-unknown-unknown --no-default-features --features web

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,4 @@ jobs:
       - name: Run tests
         run: cargo test --verbose
       - name: Check wasm build
-        run: cargo check --target wasm32-unknown-unknown --no-default-features --features web
+        run: cargo check --target wasm32-unknown-unknown --no-default-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,5 +35,7 @@ jobs:
         run: cargo build --verbose
       - name: Run tests
         run: cargo test --verbose
+      - name: Install wasm target
+        run: rustup target add wasm32-unknown-unknown
       - name: Check wasm build
         run: cargo check --target wasm32-unknown-unknown --no-default-features

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,6 @@ use std::{ffi::c_void, fmt, time::Duration};
 
 #[cfg(target_arch = "wasm32")]
 use std::panic;
-#[cfg(target_arch = "wasm32")]
-use web_sys::HtmlElement;
 
 #[cfg(target_os = "macos")]
 use os::macos as imp;

--- a/src/os/wasm/mod.rs
+++ b/src/os/wasm/mod.rs
@@ -220,7 +220,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_rate(&mut self, rate: Option<Duration>) {}
+    pub fn set_rate(&mut self, _rate: Option<Duration>) {}
 
     #[inline]
     pub fn update_rate(&mut self) {}
@@ -231,7 +231,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn topmost(&self, topmost: bool) {
+    pub fn topmost(&self, _topmost: bool) {
         // TODO?
     }
 
@@ -312,10 +312,10 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_icon(&mut self, icon: Icon) {}
+    pub fn set_icon(&mut self, _icon: Icon) {}
 
     #[inline]
-    pub fn set_position(&mut self, x: isize, y: isize) {}
+    pub fn set_position(&mut self, _x: isize, _y: isize) {}
 
     #[inline]
     pub fn get_position(&self) -> (isize, isize) {
@@ -372,7 +372,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_cursor_style(&mut self, cursor: CursorStyle) {}
+    pub fn set_cursor_style(&mut self, _cursor: CursorStyle) {}
 
     #[inline]
     pub fn get_keys(&self) -> Vec<Key> {
@@ -474,7 +474,7 @@ impl Menu {
     }
 
     #[inline]
-    pub fn add_sub_menu(&mut self, name: &str, sub_menu: &Menu) {}
+    pub fn add_sub_menu(&mut self, _name: &str, _sub_menu: &Menu) {}
 
     #[inline]
     fn next_item_handle(&mut self) -> MenuItemHandle {
@@ -499,7 +499,7 @@ impl Menu {
     }
 
     #[inline]
-    pub fn remove_item(&mut self, handle: &MenuItemHandle) {}
+    pub fn remove_item(&mut self, _handle: &MenuItemHandle) {}
 }
 
 impl HasWindowHandle for Window {

--- a/src/os/wasm/mod.rs
+++ b/src/os/wasm/mod.rs
@@ -54,6 +54,7 @@ pub struct Window {
     key_handler: Rc<RefCell<KeyHandler>>,
     menu_counter: MenuHandle,
     menus: Vec<UnixMenu>,
+    raw_handle_id: u32,
 }
 
 impl Window {
@@ -81,6 +82,13 @@ impl Window {
             .create_element("canvas")
             .unwrap()
             .dyn_into::<HtmlCanvasElement>()
+            .unwrap();
+
+        // Raw handle requires to inject an id into the canvas' data attributes.
+        // TODO assign a different ID to each window
+        let raw_handle_id = 0;
+        canvas
+            .set_attribute("data-raw-handle", &raw_handle_id.to_string())
             .unwrap();
 
         let container = document
@@ -192,6 +200,7 @@ impl Window {
             mouse_state,
             menu_counter: MenuHandle(0),
             menus: Vec::new(),
+            raw_handle_id,
         };
 
         Ok(window)
@@ -475,8 +484,7 @@ impl Menu {
 
 impl HasWindowHandle for Window {
     fn window_handle(&self) -> std::result::Result<WindowHandle, HandleError> {
-        // TODO assign a different ID to each window
-        let handle = WebWindowHandle::new(0);
+        let handle = WebWindowHandle::new(self.raw_handle_id);
         let raw_handle = RawWindowHandle::Web(handle);
         unsafe { Ok(WindowHandle::borrow_raw(raw_handle)) }
     }

--- a/src/os/wasm/mod.rs
+++ b/src/os/wasm/mod.rs
@@ -184,7 +184,7 @@ impl Window {
             closure.forget();
         }
 
-        let mut window = Window {
+        Ok(Window {
             width: width as u32,
             height: height as u32,
             bg_color: 0,
@@ -196,9 +196,7 @@ impl Window {
             menu_counter: MenuHandle(0),
             menus: Vec::new(),
             raw_handle_id,
-        };
-
-        Ok(window)
+        })
     }
 
     fn create_2d_context(&self) -> CanvasRenderingContext2d {
@@ -426,8 +424,10 @@ impl Window {
 
     #[inline]
     pub fn is_active(&mut self) -> bool {
-        let document = window().unwrap().document().unwrap();
-        document.active_element().unwrap_or(return false) == **self.canvas
+        window()
+            .and_then(|window| window.document())
+            .and_then(|document| document.active_element())
+            .map_or(false, |element| element == **self.canvas)
     }
 
     #[inline]

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -5,11 +5,13 @@ use instant::{Duration, Instant};
 #[cfg(not(target_arch = "wasm32"))]
 use std::time::{Duration, Instant};
 
+#[cfg_attr(target_arch = "wasm32", allow(unused))]
 pub struct UpdateRate {
     target_rate: Option<Duration>,
     prev_time: Instant,
 }
 
+#[cfg_attr(target_arch = "wasm32", allow(unused))]
 impl UpdateRate {
     pub fn new() -> UpdateRate {
         UpdateRate {


### PR DESCRIPTION
Also, fixed various warnings & added a CI step to check the wasm target.

The reason [`getContext`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext) have to be delayed here is that this stateful: Once `getContext` is called with one type of context (`2d`, `webgl` or `webgpu`), any future call with a different type will fail.
-> Previously, it was not possible to use the canvas with a WebGL/WebGPU context since `minifb` would call `.get_context("2d")` during initialization.

Tested this on https://github.com/Wumpf/minifb_wgpu_web_and_desktop (at https://github.com/Wumpf/minifb_wgpu_web_and_desktop/commit/e39be06686b9b8662d27fd4cb0a3787dfaee172d)