### PR TITLE
Build - Remove use of `cfg!` and instead inspect `TARGET`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -19,21 +19,18 @@ fn main() {
     // target_arch is not working? OS FAMILY and ARCH variables were empty too
     // I think the cross-compilation is broken. We could take these from the environment,
     // since the build script seems to have a different target_arch than the destination.
-    let target = env::var("TARGET").unwrap_or("".to_string());
+    let target = env::var("TARGET").expect("cargo should have set $TARGET");
     if target != "wasm32-unknown-unknown"
-        && cfg!(not(any(
-            target_os = "macos",
-            target_os = "windows",
-            target_os = "redox",
-            target_arch = "wasm32", // this is ignored. Why?
-        )))
+        && !target.contains("-macos")
+		&& !target.contains("-windows")
+		&& !target.contains("-redox")
+		&& !target.starts_with("wasm32-")	// this is ignored. Why?
         && cfg!(not(any(feature = "wayland", feature = "x11")))
     {
         panic!("At least one of the x11 or wayland features must be enabled");
     }
 
-    let env = env::var("TARGET").unwrap();
-    if env.contains("darwin") {
+    if target.contains("darwin") {
         cc::Build::new()
             .flag("-mmacosx-version-min=10.10")
             .file("src/native/macosx/MacMiniFB.m")
@@ -42,7 +39,7 @@ fn main() {
             .compile("libminifb_native.a");
         println!("cargo:rustc-link-lib=framework=Metal");
         println!("cargo:rustc-link-lib=framework=MetalKit");
-    } else if !env.contains("windows") && !env.contains("wasm32") {
+    } else if !target.contains("windows") && !target.contains("wasm32") {
         // build scalar on non-windows and non-mac
         cc::Build::new()
             .file("src/native/posix/scalar.c")


### PR DESCRIPTION
This fixes cross-compilation, as beforehand it would require the Linux windowing system features (X11 or Wayland) even when building for windows (on a linux host).

Tested locally using both linux->linux compilation (both that it builds with default-features, and errors without) and linux->windows (doesn't) error)

Fixes #373 