### PR TITLE
Fix `is_active` requiring `&mut self` rather than `&self`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -859,7 +859,7 @@ impl Window {
 
     /// Returns if this windows is the current active one
     #[inline]
-    pub fn is_active(&mut self) -> bool {
+    pub fn is_active(&self) -> bool {
         self.0.is_active()
     }
 

--- a/src/os/macos/mod.rs
+++ b/src/os/macos/mod.rs
@@ -181,7 +181,7 @@ extern "C" {
     fn mfb_set_cursor_visibility(window: *mut c_void, visibility: bool);
     fn mfb_should_close(window: *mut c_void) -> i32;
     fn mfb_get_screen_size() -> u32;
-    fn mfb_is_active(window: *mut c_void) -> u32;
+    fn mfb_is_active(window: *const c_void) -> u32;
     fn mfb_add_menu(window: *mut c_void, menu: *mut c_void) -> u64;
     fn mfb_add_sub_menu(parent_menu: *mut c_void, name: *const c_char, menu: *mut c_void);
     fn mfb_active_menu(window: *mut c_void) -> i32;
@@ -574,7 +574,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn is_active(&mut self) -> bool {
+    pub fn is_active(&self) -> bool {
         unsafe { mfb_is_active(self.window_handle) == 0 }
     }
 

--- a/src/os/posix/mod.rs
+++ b/src/os/posix/mod.rs
@@ -324,7 +324,7 @@ impl Window {
         }
     }
 
-    pub fn is_active(&mut self) -> bool {
+    pub fn is_active(&self) -> bool {
         match self {
             #[cfg(feature = "x11")]
             Window::X11(w) => w.is_active(),

--- a/src/os/posix/x11.rs
+++ b/src/os/posix/x11.rs
@@ -818,7 +818,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn is_active(&mut self) -> bool {
+    pub fn is_active(&self) -> bool {
         self.active
     }
 

--- a/src/os/redox/mod.rs
+++ b/src/os/redox/mod.rs
@@ -247,7 +247,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn is_active(&mut self) -> bool {
+    pub fn is_active(&self) -> bool {
         self.is_active
     }
 

--- a/src/os/wasm/mod.rs
+++ b/src/os/wasm/mod.rs
@@ -423,7 +423,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn is_active(&mut self) -> bool {
+    pub fn is_active(&self) -> bool {
         window()
             .and_then(|window| window.document())
             .and_then(|document| document.active_element())

--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -1002,7 +1002,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn is_active(&mut self) -> bool {
+    pub fn is_active(&self) -> bool {
         let active = unsafe { winapi::um::winuser::GetActiveWindow() };
         !active.is_null() && active == self.hwnd
     }


### PR DESCRIPTION
(see title)