### PR TITLE
Released keys detection is broken on Wayland

### DIFF
--- a/src/os/posix/wayland.rs
+++ b/src/os/posix/wayland.rs
@@ -776,6 +776,8 @@ impl Window {
             self.should_close = true;
         }
 
+        self.key_handler.update();
+
         for event in self.input.iter_keyboard_events() {
             use wayland_client::protocol::wl_keyboard::Event;
 
@@ -951,8 +953,6 @@ impl Window {
                 _ => {}
             }
         }
-
-        self.key_handler.update();
     }
 
     fn handle_key(


### PR DESCRIPTION
See commit message for the fix made and issue for context (don't want to duplicate information).

Fixes: #377

P.S. suggest merge commit as is since it contains valuable information.