### PR TITLE
Add back and forward mouse buttons

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,10 @@ pub enum MouseButton {
     Middle,
     /// Right mouse button
     Right,
+    /// Back mouse button
+    Back,
+    /// Forward mouse button
+    Forward,
 }
 
 /// The different modes that can be used to decide how mouse coordinates should be handled

--- a/src/native/macosx/OSXWindowFrameView.m
+++ b/src/native/macosx/OSXWindowFrameView.m
@@ -375,6 +375,30 @@ uint32_t upper_power_of_two(uint32_t v) {
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+- (void)otherMouseDown:(NSEvent*)event {
+    (void)event;
+    OSXWindow* window = (OSXWindow*)[self window];
+
+    NSInteger button = [event buttonNumber];
+    if (button == 3 || button == 4) {
+        window->shared_data->mouse_state[button] = 1;
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+- (void)otherMouseUp:(NSEvent*)event {
+    (void)event;
+    OSXWindow* window = (OSXWindow*)[self window];
+
+    NSInteger button = [event buttonNumber];
+    if (button == 3 || button == 4) {
+        window->shared_data->mouse_state[button] = 0;
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 - (void)scrollWheel:(NSEvent *)event {
     OSXWindow* window = (OSXWindow*)[self window];
     window->shared_data->scroll_x = [event deltaX];

--- a/src/os/macos/mod.rs
+++ b/src/os/macos/mod.rs
@@ -462,6 +462,8 @@ impl Window {
             MouseButton::Left => self.shared_data.state[0] > 0,
             MouseButton::Middle => self.shared_data.state[1] > 0,
             MouseButton::Right => self.shared_data.state[2] > 0,
+            MouseButton::Back => self.shared_data.state[3] > 0,
+            MouseButton::Forward => self.shared_data.state[4] > 0,
         }
     }
 

--- a/src/os/posix/wayland.rs
+++ b/src/os/posix/wayland.rs
@@ -53,6 +53,8 @@ const KEY_XKB_OFFSET: u32 = 8;
 const KEY_MOUSE_BTN1: u32 = 272;
 const KEY_MOUSE_BTN2: u32 = 273;
 const KEY_MOUSE_BTN3: u32 = 274;
+const KEY_MOUSE_BTN8: u32 = 275;
+const KEY_MOUSE_BTN9: u32 = 276;
 
 type ToplevelResolution = Rc<RefCell<Option<(i32, i32)>>>;
 type ToplevelClosed = Rc<RefCell<bool>>;
@@ -621,6 +623,8 @@ impl Window {
             MouseButton::Left => self.buttons[0],
             MouseButton::Right => self.buttons[1],
             MouseButton::Middle => self.buttons[2],
+            MouseButton::Back => self.buttons[3],
+            MouseButton::Forward => self.buttons[4],
         }
     }
 
@@ -892,10 +896,14 @@ impl Window {
                         KEY_MOUSE_BTN2 => self.buttons[1] = pressed,
                         // Middle mouse button
                         KEY_MOUSE_BTN3 => self.buttons[2] = pressed,
-                        _ => {
+                        // Back mouse button
+                        KEY_MOUSE_BTN8 => self.buttons[3] = pressed,
+                        // Forward mouse button
+                        KEY_MOUSE_BTN9 => self.buttons[4] = pressed,
+                        _ => (
                             // TODO: handle more mouse buttons (see: linux/input-event-codes.h from
                             // the Linux kernel)
-                        }
+                        ),
                     }
 
                     if self.pointer_visibility {

--- a/src/os/posix/x11.rs
+++ b/src/os/posix/x11.rs
@@ -27,9 +27,11 @@ use x11_dl::{
     },
 };
 
-// NOTE: the x11-dl crate does not define Button6 or Button7
+// NOTE: the x11-dl crate does not define Button6, Button7, Button8, and Button9
 const Button6: c_uint = xlib::Button5 + 1;
 const Button7: c_uint = xlib::Button5 + 2;
+const Button8: c_uint = xlib::Button5 + 3;
+const Button9: c_uint = xlib::Button5 + 4;
 
 #[repr(C)]
 struct MwmHints {
@@ -269,7 +271,7 @@ pub struct Window {
     mouse_y: f32,
     scroll_x: f32,
     scroll_y: f32,
-    buttons: [u8; 3],
+    buttons: [u8; 5],
     prev_cursor: CursorStyle,
     active: bool,
 
@@ -487,7 +489,7 @@ impl Window {
                 scroll_y: 0.0,
                 bg_color: 0,
                 scale_mode: opts.scale_mode,
-                buttons: [0, 0, 0],
+                buttons: [0, 0, 0, 0, 0],
                 prev_cursor: CursorStyle::Arrow,
                 should_close: false,
                 active: false,
@@ -731,6 +733,8 @@ impl Window {
             MouseButton::Left => self.buttons[0] > 0,
             MouseButton::Middle => self.buttons[1] > 0,
             MouseButton::Right => self.buttons[2] > 0,
+            MouseButton::Back => self.buttons[3] > 0,
+            MouseButton::Forward => self.buttons[4] > 0,
         }
     }
 
@@ -1175,6 +1179,16 @@ impl Window {
             }
             xlib::Button3 => {
                 self.buttons[2] = if is_down { 1 } else { 0 };
+                return;
+            }
+
+            Button8 => {
+                self.buttons[3] = if is_down { 1 } else { 0 };
+                return;
+            }
+
+            Button9 => {
+                self.buttons[4] = if is_down { 1 } else { 0 };
                 return;
             }
 

--- a/src/os/redox/mod.rs
+++ b/src/os/redox/mod.rs
@@ -153,6 +153,8 @@ impl Window {
             MouseButton::Left => self.mouse_state.0,
             MouseButton::Middle => self.mouse_state.1,
             MouseButton::Right => self.mouse_state.2,
+            MouseButton::Back => unimplemented!("Back button is not supported"),
+            MouseButton::Forward => unimplemented!("Forward button is not supported"),
         }
     }
 

--- a/src/os/wasm/mod.rs
+++ b/src/os/wasm/mod.rs
@@ -39,6 +39,8 @@ struct MouseState {
     left_button: Cell<bool>,
     right_button: Cell<bool>,
     middle_button: Cell<bool>,
+    back_button: Cell<bool>,
+    forward_button: Cell<bool>,
 }
 
 struct Context2D {
@@ -117,6 +119,8 @@ impl Window {
             left_button: Cell::new(false),
             right_button: Cell::new(false),
             middle_button: Cell::new(false),
+            back_button: Cell::new(false),
+            forward_button: Cell::new(false),
         };
         let mouse_state = Rc::new(mouse_struct);
         {
@@ -149,6 +153,8 @@ impl Window {
                     0 => mouse_state.left_button.set(true),
                     1 => mouse_state.middle_button.set(true),
                     2 => mouse_state.right_button.set(true),
+                    3 => mouse_state.back_button.set(true),
+                    4 => mouse_state.forward_button.set(true),
                     _ => (),
                 }
             }) as Box<dyn FnMut(_)>);
@@ -177,6 +183,8 @@ impl Window {
                     0 => mouse_state.left_button.set(false),
                     1 => mouse_state.middle_button.set(false),
                     2 => mouse_state.right_button.set(false),
+                    3 => mouse_state.back_button.set(false),
+                    4 => mouse_state.forward_button.set(false),
                     _ => (),
                 }
             }) as Box<dyn FnMut(_)>);
@@ -361,6 +369,8 @@ impl Window {
             MouseButton::Left => self.mouse_state.left_button.get(),
             MouseButton::Middle => self.mouse_state.middle_button.get(),
             MouseButton::Right => self.mouse_state.right_button.get(),
+            MouseButton::Back => self.mouse_state.back_button.get(),
+            MouseButton::Forward => self.mouse_state.forward_button.get(),
         }
     }
 

--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -27,7 +27,8 @@ use winapi::{
         fileapi::GetFullPathNameW,
         libloaderapi, wingdi,
         winuser::{
-            self, ICON_BIG, ICON_SMALL, IMAGE_ICON, LR_DEFAULTSIZE, LR_LOADFROMFILE, WM_SETICON,
+            self, GET_XBUTTON_WPARAM, ICON_BIG, ICON_SMALL, IMAGE_ICON, LR_DEFAULTSIZE,
+            LR_LOADFROMFILE, WM_SETICON,
         },
     },
 };
@@ -273,6 +274,15 @@ unsafe extern "system" fn wnd_proc(
         winuser::WM_MBUTTONUP => wnd.mouse.state[1] = false,
         winuser::WM_RBUTTONDOWN => wnd.mouse.state[2] = true,
         winuser::WM_RBUTTONUP => wnd.mouse.state[2] = false,
+
+        winuser::WM_XBUTTONDOWN => {
+            let button = GET_XBUTTON_WPARAM(wparam); // XBUTTON1 or XBUTTON2
+            wnd.mouse.state[2 + button as usize] = true;
+        }
+        winuser::WM_XBUTTONUP => {
+            let button = GET_XBUTTON_WPARAM(wparam); // XBUTTON1 or XBUTTON2
+            wnd.mouse.state[2 + button as usize] = false;
+        }
 
         winuser::WM_CLOSE => {
             wnd.is_open = false;
@@ -836,6 +846,8 @@ impl Window {
             MouseButton::Left => self.mouse.state[0],
             MouseButton::Middle => self.mouse.state[1],
             MouseButton::Right => self.mouse.state[2],
+            MouseButton::Back => self.mouse.state[3],
+            MouseButton::Forward => self.mouse.state[4],
         }
     }
 


### PR DESCRIPTION
This PR adds support for back and forward mouse buttons.

I've tested it and confirmed that it works correctly on POSIX (X11/Wayland), Windows, and WebAssembly.

Regarding macOS, I wrote the implementation based on existing code and some research, but I haven't been able to test it. It would be great if someone could verify whether it works as expected.

As for Redox, it appears that the underlying library does not support these buttons. Therefore, there's nothing that can be done at the moment. I've added match arms for completeness and used the `unimplemented!` macro to handle those cases.