### PR TITLE
: Replace unmaintained instant with web-time.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ cc = "1.0"
 
 [dependencies]
 raw-window-handle = "0.6"
+web-time = "1.1"
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3.9"
@@ -93,7 +94,6 @@ lazy_static = { version = "1.0", optional = true }
 orbclient = "0.3.20"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-instant = { version = "0.1.12", features = ["wasm-bindgen", "inaccurate"] }
 js-sys = "0.3.56"
 wasm-bindgen-futures = "0.4.29"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/src/key_handler.rs
+++ b/src/key_handler.rs
@@ -1,10 +1,4 @@
-#[cfg(target_arch = "wasm32")]
-extern crate instant;
-
-#[cfg(target_arch = "wasm32")]
-use instant::{Duration, Instant};
-#[cfg(not(target_arch = "wasm32"))]
-use std::time::{Duration, Instant};
+use web_time::{Duration, Instant};
 
 use crate::{InputCallback, Key, KeyRepeat};
 

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -1,9 +1,4 @@
-#[cfg(target_arch = "wasm32")]
-extern crate instant;
-#[cfg(target_arch = "wasm32")]
-use instant::{Duration, Instant};
-#[cfg(not(target_arch = "wasm32"))]
-use std::time::{Duration, Instant};
+use web_time::{Duration, Instant};
 
 #[cfg_attr(target_arch = "wasm32", allow(unused))]
 pub struct UpdateRate {


### PR DESCRIPTION
The `instant` crate is unmaintained.
This PR replaces it with `web-time`.

It works for all my projects, but **I do not have a wasm based project**. The tests compile for wasm, but I didn't run them!

web-time re-exports Duration and Instant from std::time on non wasm platforms, so it can handle the platform abstraction internally.