### PR TITLE
mac: fix keyUp while cmd pressed

### DIFF
--- a/src/native/macosx/OSXWindow.h
+++ b/src/native/macosx/OSXWindow.h
@@ -51,5 +51,6 @@ void build_submenu(NSMenu* menu, MenuDesc* desc);
     @public int prev_cursor;
     @public MenuData* menu_data;
     @public void* frame_view;
+    @public id keyUpMonitor;
 }
 @end

--- a/src/native/macosx/OSXWindow.m
+++ b/src/native/macosx/OSXWindow.m
@@ -5,7 +5,36 @@
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+- (id)initWithContentRect:(NSRect)contentRect
+                styleMask:(NSWindowStyleMask)style
+                  backing:(NSBackingStoreType)backingStoreType
+                    defer:(BOOL)flag {
+    self = [super initWithContentRect:contentRect styleMask:style backing:backingStoreType defer:flag];
+    if (self) {
+        // Install keyUp monitor to handle keyUp events when Command is pressed
+        __block OSXWindow* blockSelf = self;
+        keyUpMonitor = [NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskKeyUp
+                                                              handler:^NSEvent*(NSEvent* event)
+        {
+            if ([event modifierFlags] & NSEventModifierFlagCommand)
+            {
+                if ([event window] == blockSelf)
+                    [blockSelf sendEvent:event];
+            }
+            return event;
+        }];
+    }
+    return self;
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 - (void)dealloc {
+    if (keyUpMonitor) {
+        [NSEvent removeMonitor:keyUpMonitor];
+        keyUpMonitor = nil;
+    }
+    
     [[NSNotificationCenter defaultCenter]
         removeObserver:self];
     [super dealloc];


### PR DESCRIPTION
Problem: keyUp events were not being sent (to InputCallback) on mac while the command key was pressed. 

I tried messing with acceptsFirstResponder, adding different views, etc. but I couldn't get macOS to send these events.
But addLocalMonitorForEventsMatchingMask:NSEventMaskKeyUp seems to work consistently. This is an application-wide hook, though, so the code has to filter the events to ensure each window only handles those meant for it. It's slightly inefficient in that each window registers its own monitor, but I couldn't see an obvious way to avoid that.

Caution: I know next to nothing about macOS programming. Multiple LLMs helped me figure this out.