### PR TITLE
Update minimum macOS version to resolve build issue

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -32,7 +32,7 @@ fn main() {
 
     if target.contains("darwin") {
         cc::Build::new()
-            .flag("-mmacosx-version-min=10.10")
+            .flag("-mmacosx-version-min=10.11")
             .file("src/native/macosx/MacMiniFB.m")
             .file("src/native/macosx/OSXWindow.m")
             .file("src/native/macosx/OSXWindowFrameView.m")


### PR DESCRIPTION
On macOS 26, encountering an issue where the library refuses to compile because some classes ('MTKView') are not available to target >10.11, but the build script in this repository was setting the minimum target to 10.10. Edited the build script, now the library builds fine.