### PR TITLE
Scale::FitScreen creates too big windows

### DIFF
--- a/src/os/macos/mod.rs
+++ b/src/os/macos/mod.rs
@@ -599,18 +599,17 @@ impl Window {
                 let screen_y = (wh & 0xffff) as i32;
 
                 let mut scale = 1i32;
-
                 loop {
-                    let w = width as i32 * (scale + 1);
-                    let h = height as i32 * (scale + 1);
+                    let next_scale = scale + 1;
+                    let w = width as i32 * next_scale;
+                    let h = height as i32 * next_scale;
 
                     if w > screen_x || h > screen_y {
                         break;
                     }
 
-                    scale *= 2;
+                    scale = next_scale;
                 }
-
                 scale
             }
         };

--- a/src/os/macos/mod.rs
+++ b/src/os/macos/mod.rs
@@ -599,6 +599,7 @@ impl Window {
                 let screen_y = (wh & 0xffff) as i32;
 
                 let mut scale = 1i32;
+
                 loop {
                     let next_scale = scale + 1;
                     let w = width as i32 * next_scale;
@@ -610,6 +611,7 @@ impl Window {
 
                     scale = next_scale;
                 }
+
                 scale
             }
         };

--- a/src/os/posix/x11.rs
+++ b/src/os/posix/x11.rs
@@ -849,11 +849,12 @@ impl Window {
             Scale::X16 => 16,
             Scale::X32 => 32,
             Scale::FitScreen => {
-                let mut scale = 1i32;
+                let mut scale = 1usize;
+
                 loop {
                     let next_scale = scale + 1;
-                    let w = width as i32 * next_scale;
-                    let h = height as i32 * next_scale;
+                    let w = width * next_scale;
+                    let h = height * next_scale;
 
                     if w > screen_width || h > screen_height {
                         break;
@@ -861,6 +862,8 @@ impl Window {
 
                     scale = next_scale;
                 }
+
+                scale
             }
         }
     }

--- a/src/os/posix/x11.rs
+++ b/src/os/posix/x11.rs
@@ -849,24 +849,17 @@ impl Window {
             Scale::X16 => 16,
             Scale::X32 => 32,
             Scale::FitScreen => {
-                let mut scale = 1;
-
+                let mut scale = 1i32;
                 loop {
-                    let next_scale = scale * 2;
-                    let w = width * next_scale;
-                    let h = height * next_scale;
+                    let next_scale = scale + 1;
+                    let w = width as i32 * next_scale;
+                    let h = height as i32 * next_scale;
 
                     if w > screen_width || h > screen_height {
                         break;
                     }
 
                     scale = next_scale;
-                }
-
-                if scale >= 32 {
-                    32
-                } else {
-                    scale
                 }
             }
         }

--- a/src/os/redox/mod.rs
+++ b/src/os/redox/mod.rs
@@ -41,14 +41,18 @@ impl Window {
             Scale::FitScreen => {
                 let display_size = orbclient::get_display_size()
                     .map_err(|_| Error::WindowCreate("Unable to get display size".to_owned()))?;
-                let mut scale = 32;
-                while scale > 1 {
-                    if width * scale < display_size.0 as usize
-                        && height * scale < display_size.1 as usize
-                    {
+                
+                let mut scale = 1i32;
+                loop {
+                    let next_scale = scale + 1;
+                    let w = width as i32 * next_scale;
+                    let h = height as i32 * next_scale;
+
+                    if w > display_size.0 || h > display_size.1 {
                         break;
                     }
-                    scale -= 1;
+
+                    scale = next_scale;
                 }
                 scale
             }

--- a/src/os/redox/mod.rs
+++ b/src/os/redox/mod.rs
@@ -41,19 +41,21 @@ impl Window {
             Scale::FitScreen => {
                 let display_size = orbclient::get_display_size()
                     .map_err(|_| Error::WindowCreate("Unable to get display size".to_owned()))?;
-                
-                let mut scale = 1i32;
+
+                let mut scale = 1usize;
+
                 loop {
                     let next_scale = scale + 1;
-                    let w = width as i32 * next_scale;
-                    let h = height as i32 * next_scale;
+                    let w = width * next_scale;
+                    let h = height * next_scale;
 
-                    if w > display_size.0 || h > display_size.1 {
+                    if w > display_size.0 as usize || h > display_size.1 as usize {
                         break;
                     }
 
                     scale = next_scale;
                 }
+
                 scale
             }
         };

--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -1038,6 +1038,7 @@ impl Window {
                 let screen_y = unsafe { winuser::GetSystemMetrics(winuser::SM_CYSCREEN) } as i32;
 
                 let mut scale = 1i32;
+
                 loop {
                     let next_scale = scale + 1;
                     let w = width as i32 * next_scale;
@@ -1049,6 +1050,7 @@ impl Window {
 
                     scale = next_scale;
                 }
+
                 std::cmp::max(1, scale - 1) //reduce slightly so we don't go over the taskbar
             }
         };

--- a/src/os/windows/mod.rs
+++ b/src/os/windows/mod.rs
@@ -1038,19 +1038,18 @@ impl Window {
                 let screen_y = unsafe { winuser::GetSystemMetrics(winuser::SM_CYSCREEN) } as i32;
 
                 let mut scale = 1i32;
-
                 loop {
-                    let w = width as i32 * (scale + 1);
-                    let h = height as i32 * (scale + 1);
+                    let next_scale = scale + 1;
+                    let w = width as i32 * next_scale;
+                    let h = height as i32 * next_scale;
 
                     if w > screen_x || h > screen_y {
                         break;
                     }
 
-                    scale *= 2;
+                    scale = next_scale;
                 }
-
-                scale
+                std::cmp::max(1, scale - 1) //reduce slightly so we don't go over the taskbar
             }
         };
 


### PR DESCRIPTION
The current code has a window scaling bug for `Scale::FitScreen` that persists across almost all of the supported platforms.
The code makes an incorrect check for if the next scale increment would be too big, this pull request resolves this.

I have also standardized the algorithm across all currently supported platforms to ensure the issue is solved for others on other platforms.
The code also scaled in different increments across different platforms. This is now also standardized.