### PR TITLE
fix(macos): treat keycode 128 as unknown (off-by-one bounds)

### DIFF
--- a/src/os/macos/mod.rs
+++ b/src/os/macos/mod.rs
@@ -233,7 +233,9 @@ unsafe extern "C" fn key_callback(window: *mut c_void, key: i32, state: i32) {
 
     let s = state == 1;
 
-    if key > 128 {
+    // KEY_MAPPINGS is length 128 (indices 0..127). key == 128 was
+    // previously treated as in-bounds and panicked on index.
+    if key < 0 || key >= 128 {
         (*win).key_handler.set_key_state(Key::Unknown, s);
     } else {
         (*win)


### PR DESCRIPTION
## Summary

On macOS, `key_callback` used `if key > 128` before indexing `KEY_MAPPINGS: [Key; 128]`. Keycode **128** was treated as in-bounds and panicked with an out-of-range index inside an `extern "C"` ObjC callback.

The check is now `key < 0 || key >= 128`, mapping those codes to `Key::Unknown`.

Fixes #413

## Test plan

- [x] `cargo check` on the branch
- [x] Reviewed `KEY_MAPPINGS` length (128) against the new bound