### PR TITLE
fix: include payload in Error Display impl (#426)

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -16,9 +16,9 @@ impl fmt::Display for Error {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::MenusNotSupported => write!(formatter, "Menus not supported"),
-            Error::MenuExists(_) => write!(formatter, "Menu already exists"),
-            Error::WindowCreate(_) => write!(formatter, "Failed to create window"),
-            Error::UpdateFailed(_) => write!(formatter, "Failed to Update"),
+            Error::MenuExists(ref e) => write!(formatter, "Menu already exists: {e}"),
+            Error::WindowCreate(ref e) => write!(formatter, "Failed to create window: {e}"),
+            Error::UpdateFailed(ref e) => write!(formatter, "Failed to Update: {e}"),
         }
     }
 }
@@ -35,6 +35,30 @@ impl fmt::Debug for Error {
 }
 
 impl std::error::Error for Error {}
+
+#[cfg(test)]
+mod tests {
+    use super::Error;
+
+    #[test]
+    fn display_includes_payload() {
+        // The payload string must reach `Display` / `to_string()` so detailed
+        // messages (e.g. from check_buffer_size) are not lost (see #426).
+        assert_eq!(
+            Error::UpdateFailed("buffer too small".to_string()).to_string(),
+            "Failed to Update: buffer too small"
+        );
+        assert_eq!(
+            Error::WindowCreate("no backend".to_string()).to_string(),
+            "Failed to create window: no backend"
+        );
+        assert_eq!(
+            Error::MenuExists("File".to_string()).to_string(),
+            "Menu already exists: File"
+        );
+        assert_eq!(Error::MenusNotSupported.to_string(), "Menus not supported");
+    }
+}
 
 #[cfg(target_arch = "wasm32")]
 impl From<wasm_bindgen::JsValue> for Error {


### PR DESCRIPTION
## What

Closes #426.

The `Display` impl for `Error` printed only the variant name and discarded the `String` payload:

```rust
Error::MenuExists(_)   => write!(formatter, "Menu already exists"),
Error::WindowCreate(_) => write!(formatter, "Failed to create window"),
Error::UpdateFailed(_) => write!(formatter, "Failed to Update"),
```

So a detailed message — for example the buffer-size explanation built in `check_buffer_size` (`src/lib.rs`) — never reached `err.to_string()`, `println!("{}", err)`, or `Box<dyn Error>` reporting; it was only visible via `{:?}`.

## Fix

Bind and include the payload in `Display`:

```rust
Error::MenuExists(ref e)   => write!(formatter, "Menu already exists: {e}"),
Error::WindowCreate(ref e) => write!(formatter, "Failed to create window: {e}"),
Error::UpdateFailed(ref e) => write!(formatter, "Failed to Update: {e}"),
```

`Debug` is left unchanged (it already includes the payload).

## Tests

Added a unit test asserting `to_string()` includes the payload for each variant.

**Verified RED→GREEN:** with the old `Display`, the test fails (`left: "Failed to Update"`, `right: "Failed to Update: buffer too small"`); with the fix it passes.

## Validation (real results)

- `cargo test --lib display_includes_payload`: **passes**.
- `cargo fmt --check`: clean.
