### PR TITLE
fix(wayland): shifted-keysym drops and a present-failure key desync

### DIFF
--- a/src/key_handler.rs
+++ b/src/key_handler.rs
@@ -49,7 +49,26 @@ impl KeyHandler {
         keys
     }
 
-    pub fn update(&mut self) {
+    /// Snapshots the current key levels as "previous", which is what
+    /// `is_key_index_released` compares against.
+    ///
+    /// A backend that applies platform key events itself must call this
+    /// *before* applying them: the release edge is `keys_prev && !keys`, so
+    /// snapshotting after a release has already been written to `keys` makes
+    /// both sides false and destroys the edge before the caller can read it.
+    pub fn snapshot_prev(&mut self) {
+        self.keys_prev.copy_from_slice(&self.keys);
+    }
+
+    /// Advances each key's held duration from the levels currently in `keys`.
+    ///
+    /// A backend that applies platform key events itself must call this
+    /// *after* applying them: `is_key_index_pressed` reports a key only while
+    /// its duration is exactly `0.0`, and a key pressed in this batch is still
+    /// at the initial `-1.0` until this runs. Advancing before the batch is
+    /// applied defers every press by a cycle, and loses it outright if the
+    /// release lands in the next batch.
+    pub fn advance_durations(&mut self) {
         self.delta_time = self.prev_time.elapsed();
         self.prev_time = Instant::now();
         let delta_time = self.delta_time.as_secs_f32();
@@ -64,8 +83,15 @@ impl KeyHandler {
             } else {
                 self.keys_down_duration[idx] = -1.0;
             }
-            self.keys_prev[idx] = self.keys[idx];
         }
+    }
+
+    /// Both phases together, for backends that apply their platform key
+    /// events outside the window this call spans (X11, macOS, Windows), where
+    /// the ordering the two phases exist to separate does not arise.
+    pub fn update(&mut self) {
+        self.snapshot_prev();
+        self.advance_durations();
     }
 
     #[inline]

--- a/src/os/posix/wayland.rs
+++ b/src/os/posix/wayland.rs
@@ -785,7 +785,10 @@ impl Window {
             self.should_close = true;
         }
 
-        self.key_handler.update();
+        // Snapshot before applying this batch, advance after it -- see the
+        // two methods' docs. This backend is the one that applies platform key
+        // events inline, so it is the one that has to split the phases.
+        self.key_handler.snapshot_prev();
 
         for event in self.input.iter_keyboard_events() {
             use wayland_client::protocol::wl_keyboard::Event;
@@ -838,6 +841,8 @@ impl Window {
                 _ => {}
             }
         }
+
+        self.key_handler.advance_durations();
 
         self.scroll_x = 0.;
         self.scroll_y = 0.;

--- a/src/os/posix/wayland.rs
+++ b/src/os/posix/wayland.rs
@@ -1041,6 +1041,69 @@ impl Window {
                 key::XKB_KEY_slash => Key::Slash,
                 key::XKB_KEY_space => Key::Space,
 
+                // Shifted-level keysyms for the keys above: XKB resolves a
+                // key through whichever shift level is currently active, so
+                // a press/release pair straddling a Shift transition (very
+                // common in ordinary typing rollover) can arrive with a
+                // different keysym for the same physical key. Without
+                // these, that keysym falls through to `_ => return` below,
+                // silently dropping the event -- on a dropped release, the
+                // key reads as permanently held and the guest's own
+                // repeat timer fires it forever; on a dropped press,
+                // Shift+key does not register at all. Map each back to
+                // the same `Key` its unshifted form uses, matching every
+                // other minifb backend's shift-invariant physical-key
+                // semantics.
+                key::XKB_KEY_A => Key::A,
+                key::XKB_KEY_B => Key::B,
+                key::XKB_KEY_C => Key::C,
+                key::XKB_KEY_D => Key::D,
+                key::XKB_KEY_E => Key::E,
+                key::XKB_KEY_F => Key::F,
+                key::XKB_KEY_G => Key::G,
+                key::XKB_KEY_H => Key::H,
+                key::XKB_KEY_I => Key::I,
+                key::XKB_KEY_J => Key::J,
+                key::XKB_KEY_K => Key::K,
+                key::XKB_KEY_L => Key::L,
+                key::XKB_KEY_M => Key::M,
+                key::XKB_KEY_N => Key::N,
+                key::XKB_KEY_O => Key::O,
+                key::XKB_KEY_P => Key::P,
+                key::XKB_KEY_Q => Key::Q,
+                key::XKB_KEY_R => Key::R,
+                key::XKB_KEY_S => Key::S,
+                key::XKB_KEY_T => Key::T,
+                key::XKB_KEY_U => Key::U,
+                key::XKB_KEY_V => Key::V,
+                key::XKB_KEY_W => Key::W,
+                key::XKB_KEY_X => Key::X,
+                key::XKB_KEY_Y => Key::Y,
+                key::XKB_KEY_Z => Key::Z,
+
+                key::XKB_KEY_exclam => Key::Key1,
+                key::XKB_KEY_at => Key::Key2,
+                key::XKB_KEY_numbersign => Key::Key3,
+                key::XKB_KEY_dollar => Key::Key4,
+                key::XKB_KEY_percent => Key::Key5,
+                key::XKB_KEY_asciicircum => Key::Key6,
+                key::XKB_KEY_ampersand => Key::Key7,
+                key::XKB_KEY_asterisk => Key::Key8,
+                key::XKB_KEY_parenleft => Key::Key9,
+                key::XKB_KEY_parenright => Key::Key0,
+
+                key::XKB_KEY_quotedbl => Key::Apostrophe,
+                key::XKB_KEY_asciitilde => Key::Backquote,
+                key::XKB_KEY_bar => Key::Backslash,
+                key::XKB_KEY_less => Key::Comma,
+                key::XKB_KEY_plus => Key::Equal,
+                key::XKB_KEY_braceleft => Key::LeftBracket,
+                key::XKB_KEY_braceright => Key::RightBracket,
+                key::XKB_KEY_underscore => Key::Minus,
+                key::XKB_KEY_greater => Key::Period,
+                key::XKB_KEY_colon => Key::Semicolon,
+                key::XKB_KEY_question => Key::Slash,
+
                 key::XKB_KEY_F1 => Key::F1,
                 key::XKB_KEY_F2 => Key::F2,
                 key::XKB_KEY_F3 => Key::F3,

--- a/src/os/posix/wayland.rs
+++ b/src/os/posix/wayland.rs
@@ -1252,16 +1252,25 @@ impl Window {
         buf_height: usize,
         buf_stride: usize,
     ) -> Result<()> {
-        check_buffer_size(buffer, buf_width, buf_height, buf_stride)?;
+        let result = (|| {
+            check_buffer_size(buffer, buf_width, buf_height, buf_stride)?;
+            unsafe { self.scale_buffer(buffer, buf_width, buf_height, buf_stride) };
+            self.display
+                .update_framebuffer(&self.buffer, (self.width, self.height))
+                .map_err(|e| Error::UpdateFailed(format!("Error updating framebuffer: {:?}", e)))
+        })();
 
-        unsafe { self.scale_buffer(buffer, buf_width, buf_height, buf_stride) };
-
-        self.display
-            .update_framebuffer(&self.buffer, (self.width, self.height))
-            .map_err(|e| Error::UpdateFailed(format!("Error updating framebuffer: {:?}", e)))?;
+        // `update()` is also where input events and the key-repeat timer
+        // advance -- it must run whether or not the present above
+        // succeeded. A caller that only calls `self.update()` on the Err
+        // branch (or not at all) leaves `key_handler`'s internal duration
+        // tracking frozen for a cycle: the next successful poll then sees
+        // an already-held key's timer still at its initial `0.0` and
+        // reports it as freshly pressed again, a spurious duplicate
+        // keystroke with no visible cause tying it to the failed present.
         self.update();
 
-        Ok(())
+        result
     }
 
     unsafe fn scale_buffer(

--- a/src/os/posix/xkb_keysyms.rs
+++ b/src/os/posix/xkb_keysyms.rs
@@ -49,6 +49,59 @@ pub const XKB_KEY_period: u32 = 0x002e;
 pub const XKB_KEY_semicolon: u32 = 0x003b;
 pub const XKB_KEY_slash: u32 = 0x002f;
 pub const XKB_KEY_space: u32 = 0x0020;
+// Shifted-level keysyms for the same physical keys above. XKB resolves a
+// key through the *active* shift level, so holding Shift changes which
+// keysym a press/release reports even though the physical key hasn't
+// changed -- these map each one back to the same `Key` its unshifted
+// counterpart uses. Values are the standard X11 keysyms (identical to
+// their Latin-1/ASCII code points in this range).
+pub const XKB_KEY_A: u32 = 0x0041;
+pub const XKB_KEY_B: u32 = 0x0042;
+pub const XKB_KEY_C: u32 = 0x0043;
+pub const XKB_KEY_D: u32 = 0x0044;
+pub const XKB_KEY_E: u32 = 0x0045;
+pub const XKB_KEY_F: u32 = 0x0046;
+pub const XKB_KEY_G: u32 = 0x0047;
+pub const XKB_KEY_H: u32 = 0x0048;
+pub const XKB_KEY_I: u32 = 0x0049;
+pub const XKB_KEY_J: u32 = 0x004a;
+pub const XKB_KEY_K: u32 = 0x004b;
+pub const XKB_KEY_L: u32 = 0x004c;
+pub const XKB_KEY_M: u32 = 0x004d;
+pub const XKB_KEY_N: u32 = 0x004e;
+pub const XKB_KEY_O: u32 = 0x004f;
+pub const XKB_KEY_P: u32 = 0x0050;
+pub const XKB_KEY_Q: u32 = 0x0051;
+pub const XKB_KEY_R: u32 = 0x0052;
+pub const XKB_KEY_S: u32 = 0x0053;
+pub const XKB_KEY_T: u32 = 0x0054;
+pub const XKB_KEY_U: u32 = 0x0055;
+pub const XKB_KEY_V: u32 = 0x0056;
+pub const XKB_KEY_W: u32 = 0x0057;
+pub const XKB_KEY_X: u32 = 0x0058;
+pub const XKB_KEY_Y: u32 = 0x0059;
+pub const XKB_KEY_Z: u32 = 0x005a;
+pub const XKB_KEY_exclam: u32 = 0x0021;
+pub const XKB_KEY_quotedbl: u32 = 0x0022;
+pub const XKB_KEY_numbersign: u32 = 0x0023;
+pub const XKB_KEY_dollar: u32 = 0x0024;
+pub const XKB_KEY_percent: u32 = 0x0025;
+pub const XKB_KEY_ampersand: u32 = 0x0026;
+pub const XKB_KEY_parenleft: u32 = 0x0028;
+pub const XKB_KEY_parenright: u32 = 0x0029;
+pub const XKB_KEY_asterisk: u32 = 0x002a;
+pub const XKB_KEY_plus: u32 = 0x002b;
+pub const XKB_KEY_colon: u32 = 0x003a;
+pub const XKB_KEY_less: u32 = 0x003c;
+pub const XKB_KEY_greater: u32 = 0x003e;
+pub const XKB_KEY_question: u32 = 0x003f;
+pub const XKB_KEY_at: u32 = 0x0040;
+pub const XKB_KEY_underscore: u32 = 0x005f;
+pub const XKB_KEY_asciicircum: u32 = 0x005e;
+pub const XKB_KEY_braceleft: u32 = 0x007b;
+pub const XKB_KEY_bar: u32 = 0x007c;
+pub const XKB_KEY_braceright: u32 = 0x007d;
+pub const XKB_KEY_asciitilde: u32 = 0x007e;
 pub const XKB_KEY_F1: u32 = 0xffbe;
 pub const XKB_KEY_F2: u32 = 0xffbf;
 pub const XKB_KEY_F3: u32 = 0xffc0;


### PR DESCRIPTION
Two real Wayland keyboard bugs found while building a remote-desktop client
(navette) that forwards physical key state over the network -- both make
the difference between "one dropped event" and "a stuck key" much sharper
than they would be for a purely local app, which is likely why they hadn't
surfaced before.

## 1. Shifted-level keysyms are silently dropped

`handle_key`'s match table only covers unshifted keysyms (lowercase
letters, unshifted punctuation). XKB resolves a key through whichever
shift level is currently active, so every shifted keysym -- capital
letters, `!`, `@`, `{`, etc. -- falls through to `_ => return` and never
reaches `set_key_state`.

Two consequences on a real keyboard:
- Shift+key does not register at all (the press itself is dropped).
- A press/release pair that straddles a Shift transition -- ordinary
  typing rollover: press a letter, press Shift for the next word, release
  the first letter while Shift is still down -- drops only the release.
  The key then reads as permanently held in `KeyHandler`'s state.

Fix maps each shifted keysym back to the same `Key` its unshifted form
already uses, matching the shift-invariant physical-key semantics every
other minifb backend has.

## 2. A failed present skips the key-repeat timer's advance

`update_with_buffer_stride` returned early via `?` on
`check_buffer_size`/`update_framebuffer` before ever calling
`self.update()` -- the only call site of `key_handler.update()`, which
advances each key's held-duration timer. A caller whose own error handling
for the `Err` doesn't also call `update()` (natural, since the point of
that branch is usually just log-and-retry) leaves the timer frozen for one
cycle. If a key had duration `0.0` (first poll after going down), the next
successful poll sees the same `0.0` again and reports it as freshly
pressed -- a duplicate keystroke with no visible cause tying it back to
the earlier failed present.

Fix runs `update()` unconditionally (captures the present result in a
closure first), so a failed present costs a frame but never desyncs input.

## Testing

Both fixes are exercised live in navette (a client that opens a real
window and forwards every keystroke over a real network connection to a
remote Wayland app), where the shifted-keysym fix was verified end-to-end:
capitals and shifted punctuation, previously untypeable, now work
correctly. `cargo test` and `cargo build --release` are clean on this
branch. I didn't add new unit tests here since `handle_key` takes a raw
XKB state pointer that isn't easily constructed in a unit test without a
real XKB context -- happy to add coverage if there's a preferred pattern
for this in the existing suite.

Two commits, one per fix, for easier review.