### PR TITLE
Fix scaler memory safety, mouse clamp panic and Key transmute

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -30,6 +30,22 @@ fn main() {
         panic!("At least one of the x11 or wayland features must be enabled");
     }
 
+    // `cc` does not emit these itself, so without them cargo keeps a stale
+    // object file when only the native sources change. Emitting any of these
+    // also switches cargo off watching the whole package, so the headers have
+    // to be listed too.
+    for source in [
+        "src/native/macosx/MacMiniFB.m",
+        "src/native/macosx/OSXWindow.h",
+        "src/native/macosx/OSXWindow.m",
+        "src/native/macosx/OSXWindowFrameView.h",
+        "src/native/macosx/OSXWindowFrameView.m",
+        "src/native/macosx/shared_data.h",
+        "src/native/posix/scalar.c",
+    ] {
+        println!("cargo:rerun-if-changed={}", source);
+    }
+
     if target.contains("darwin") {
         cc::Build::new()
             .flag("-mmacosx-version-min=10.11")

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,5 +1,10 @@
 /// Key is used by the get key functions to check if some keys on the keyboard has been pressed
+///
+/// The discriminants are contiguous from `Key0 = 0` to `Count`, and the
+/// representation is fixed to `u8` so that `key_handler` can map a key state
+/// array index back to a `Key`.
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone, Copy)]
+#[repr(u8)]
 pub enum Key {
     Key0 = 0,
     Key1 = 1,

--- a/src/key_handler.rs
+++ b/src/key_handler.rs
@@ -2,13 +2,33 @@ use web_time::{Duration, Instant};
 
 use crate::{InputCallback, Key, KeyRepeat};
 
+/// Number of slots in the key state arrays.
+///
+/// `Key` is `#[repr(u8)]` with contiguous discriminants `0..=Key::Count`, so
+/// every index below this is a valid `Key` and every `key as usize` is in
+/// range.
+const KEY_COUNT: usize = Key::Count as usize + 1;
+
+/// Converts a key state array index back into the `Key` it belongs to.
+#[inline]
+fn key_from_index(idx: usize) -> Option<Key> {
+    if idx < Key::Count as usize {
+        // SAFETY: `Key` is `#[repr(u8)]` and its discriminants are contiguous
+        // from 0 to `Key::Count`, so every `idx < Key::Count` is a valid
+        // discriminant. `Key::Count` itself is a sentinel and is excluded.
+        Some(unsafe { std::mem::transmute::<u8, Key>(idx as u8) })
+    } else {
+        None
+    }
+}
+
 pub struct KeyHandler {
     pub key_callback: Option<Box<dyn InputCallback>>,
     prev_time: Instant,
     delta_time: Duration,
-    keys: [bool; 512],
-    keys_prev: [bool; 512],
-    keys_down_duration: [f32; 512],
+    keys: [bool; KEY_COUNT],
+    keys_prev: [bool; KEY_COUNT],
+    keys_down_duration: [f32; KEY_COUNT],
     key_repeat_delay: f32,
     key_repeat_rate: f32,
 }
@@ -17,9 +37,9 @@ impl KeyHandler {
     pub fn new() -> KeyHandler {
         KeyHandler {
             key_callback: None,
-            keys: [false; 512],
-            keys_prev: [false; 512],
-            keys_down_duration: [-1.0; 512],
+            keys: [false; KEY_COUNT],
+            keys_prev: [false; KEY_COUNT],
+            keys_down_duration: [-1.0; KEY_COUNT],
             prev_time: Instant::now(),
             delta_time: Duration::from_secs(0),
             key_repeat_delay: 0.250,
@@ -40,9 +60,7 @@ impl KeyHandler {
 
         for (idx, is_down) in self.keys.iter().enumerate() {
             if *is_down {
-                unsafe {
-                    keys.push(std::mem::transmute::<u8, Key>(idx as u8));
-                }
+                keys.extend(key_from_index(idx));
             }
         }
 
@@ -105,9 +123,7 @@ impl KeyHandler {
 
         for (idx, is_down) in self.keys.iter().enumerate() {
             if *is_down && self.is_key_index_pressed(idx, repeat) {
-                unsafe {
-                    keys.push(std::mem::transmute::<u8, Key>(idx as u8));
-                }
+                keys.extend(key_from_index(idx));
             }
         }
 
@@ -119,9 +135,7 @@ impl KeyHandler {
 
         for (idx, is_down) in self.keys.iter().enumerate() {
             if !(*is_down) && self.is_key_index_released(idx) {
-                unsafe {
-                    keys.push(std::mem::transmute::<u8, Key>(idx as u8));
-                }
+                keys.extend(key_from_index(idx));
             }
         }
 
@@ -177,5 +191,29 @@ impl KeyHandler {
     #[inline]
     fn is_key_index_released(&self, idx: usize) -> bool {
         self.keys_prev[idx] && !self.keys[idx]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pins the contiguity that `key_from_index`'s transmute relies on.
+    #[test]
+    fn every_index_below_count_round_trips() {
+        for idx in 0..Key::Count as usize {
+            let key = key_from_index(idx).expect("index below Count must map to a Key");
+            assert_eq!(key as usize, idx);
+        }
+        assert_eq!(key_from_index(Key::Count as usize), None);
+        assert_eq!(key_from_index(usize::MAX), None);
+    }
+
+    #[test]
+    fn state_array_covers_every_key() {
+        let mut handler = KeyHandler::new();
+        handler.set_key_state(Key::Unknown, true);
+        assert!(handler.is_key_down(Key::Unknown));
+        assert_eq!(handler.get_keys(), vec![Key::Unknown]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,13 @@ impl MouseMode {
 
         match self {
             Self::Pass => Some((x, y)),
-            Self::Clamp => Some((x.clamp(0.0, width - 1.0), y.clamp(0.0, height - 1.0))),
+            // `max(0.0)` guards the degenerate case: a window whose
+            // scale-divided size is below one pixel makes `width - 1.0`
+            // negative, and `f32::clamp` asserts that `min <= max`.
+            Self::Clamp => Some((
+                x.clamp(0.0, (width - 1.0).max(0.0)),
+                y.clamp(0.0, (height - 1.0).max(0.0)),
+            )),
             Self::Discard => {
                 if x < 0.0 || y < 0.0 || x >= width || y >= height {
                     None
@@ -1247,5 +1253,33 @@ pub(crate) fn check_buffer_size(
         Err(Error::UpdateFailed(err))
     } else {
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod mouse_mode_tests {
+    use super::*;
+
+    /// `f32::clamp` asserts `min <= max`, so a window whose scale-divided
+    /// size drops below one pixel used to panic instead of returning a
+    /// degenerate coordinate.
+    #[test]
+    fn clamp_handles_sub_pixel_window_sizes() {
+        assert_eq!(
+            MouseMode::Clamp.get_pos(5.0, 5.0, 32.0, 16.0, 16.0),
+            Some((0.0, 0.0))
+        );
+        assert_eq!(
+            MouseMode::Clamp.get_pos(5.0, 5.0, 1.0, 0.0, 0.0),
+            Some((0.0, 0.0))
+        );
+    }
+
+    #[test]
+    fn clamp_still_clamps_normal_sizes() {
+        assert_eq!(
+            MouseMode::Clamp.get_pos(-3.0, 900.0, 1.0, 640.0, 480.0),
+            Some((0.0, 479.0))
+        );
     }
 }

--- a/src/native/posix/scalar.c
+++ b/src/native/posix/scalar.c
@@ -1,4 +1,19 @@
 #include <stdint.h>
+#include <stddef.h>
+
+// Fixed-point coordinates are accumulated in 64-bit: a source dimension above
+// 2^21 overflows a 32-bit 10.10 accumulator and wraps to a negative index,
+// which is reachable from the safe Rust API (`check_buffer_size` happily
+// accepts a 2.1M x 1 buffer).
+#define FP_SHIFT 10
+#define FP_ONE (1 << FP_SHIFT)
+
+static void image_clear(uint32_t* dst, const uint32_t dst_width, const uint32_t dst_height, const uint32_t bg_clear) {
+    const size_t count = (size_t)dst_width * (size_t)dst_height;
+    for (size_t i = 0; i < count; ++i) {
+        dst[i] = bg_clear;
+    }
+}
 
 void image_resize_linear(
     uint32_t* dst,
@@ -9,19 +24,27 @@ void image_resize_linear(
     const uint32_t src_height,
     const uint32_t src_stride
 ) {
+    if (dst_width == 0 || dst_height == 0 || src_width == 0 || src_height == 0) {
+        return;
+    }
+
     const float x_ratio = (float)(src_width) / (float)(dst_width);
     const float y_ratio = (float)(src_height) / (float)(dst_height);
-    const int step_x = x_ratio * 1024.0f;
-    const int step_y = y_ratio * 1024.0f;
-    int fixed_y = 0;
+    const int64_t step_x = (int64_t)(x_ratio * (float)FP_ONE);
+    const int64_t step_y = (int64_t)(y_ratio * (float)FP_ONE);
+    const int64_t max_x = (int64_t)src_width - 1;
+    const int64_t max_y = (int64_t)src_height - 1;
+    int64_t fixed_y = 0;
 
     for (uint32_t i = 0; i < dst_height; i++) {
-        const int y = (fixed_y >> 10) * src_stride;
-        int fixed_x = 0;
+        int64_t sy = fixed_y >> FP_SHIFT;
+        if (sy > max_y) sy = max_y;
+        const int64_t y = sy * (int64_t)src_stride;
+        int64_t fixed_x = 0;
         for (uint32_t j = 0; j < dst_width; j++) {
-            int x = fixed_x >> 10;
-            int index = (y + x);
-            *dst++ = src[index];
+            int64_t x = fixed_x >> FP_SHIFT;
+            if (x > max_x) x = max_x;
+            *dst++ = src[y + x];
             fixed_x += step_x;
         }
         fixed_y += step_y;
@@ -38,20 +61,28 @@ static void image_resize_linear_stride(
     const uint32_t src_stride,
     const uint32_t stride
 ) {
+    if (dst_width == 0 || dst_height == 0 || src_width == 0 || src_height == 0) {
+        return;
+    }
+
     const float x_ratio = (float)(src_width) / (float)(dst_width);
     const float y_ratio = (float)(src_height) / (float)(dst_height);
-    const int step_x = x_ratio * 1024.0f;
-    const int step_y = y_ratio * 1024.0f;
-    const int stride_step = stride - dst_width;
-    int fixed_y = 0;
+    const int64_t step_x = (int64_t)(x_ratio * (float)FP_ONE);
+    const int64_t step_y = (int64_t)(y_ratio * (float)FP_ONE);
+    const int64_t max_x = (int64_t)src_width - 1;
+    const int64_t max_y = (int64_t)src_height - 1;
+    const ptrdiff_t stride_step = (ptrdiff_t)stride - (ptrdiff_t)dst_width;
+    int64_t fixed_y = 0;
 
     for (uint32_t i = 0; i < dst_height; i++) {
-        const int y = (fixed_y >> 10) * src_stride;
-        int fixed_x = 0;
+        int64_t sy = fixed_y >> FP_SHIFT;
+        if (sy > max_y) sy = max_y;
+        const int64_t y = sy * (int64_t)src_stride;
+        int64_t fixed_x = 0;
         for (uint32_t j = 0; j < dst_width; j++) {
-            const int x = fixed_x >> 10;
-            const int index = (y + x);
-            *dst++ = src[index];
+            int64_t x = fixed_x >> FP_SHIFT;
+            if (x > max_x) x = max_x;
+            *dst++ = src[y + x];
             fixed_x += step_x;
         }
         dst += stride_step;
@@ -70,26 +101,36 @@ void image_resize_linear_aspect_fill(
     const uint32_t bg_clear
 ) {
     // TODO: Optimize by only clearing the areas the image blit doesn't fill
-    for (uint32_t i = 0; i < dst_width * dst_height; ++i) {
-        dst[i] = bg_clear;
+    image_clear(dst, dst_width, dst_height, bg_clear);
+
+    if (dst_width == 0 || dst_height == 0 || src_width == 0 || src_height == 0) {
+        return;
     }
 
     const float buffer_aspect = (float)(src_width) / (float)(src_height);
     const float win_aspect = (float)(dst_width) / (float)(dst_height);
 
     if (buffer_aspect > win_aspect) {
-        const uint32_t new_height = (uint32_t)(dst_width / buffer_aspect);
-        const int offset = (new_height - dst_height) / -2;
+        // Letterboxed: full width, centered vertically.
+        uint32_t new_height = (uint32_t)((float)dst_width / buffer_aspect);
+        if (new_height > dst_height) new_height = dst_height;
+        if (new_height == 0) new_height = 1;
+        const uint32_t y_offset = (dst_height - new_height) / 2;
+
         image_resize_linear(
-            dst + (offset * dst_width),
+            dst + (size_t)y_offset * (size_t)dst_width,
             dst_width, new_height,
             src, src_width, src_height, src_stride
         );
     } else {
-        const uint32_t new_width = (uint32_t)(dst_height * buffer_aspect);
-        const int offset = (new_width - dst_width) / -2;
+        // Pillarboxed: full height, centered horizontally.
+        uint32_t new_width = (uint32_t)((float)dst_height * buffer_aspect);
+        if (new_width > dst_width) new_width = dst_width;
+        if (new_width == 0) new_width = 1;
+        const uint32_t x_offset = (dst_width - new_width) / 2;
+
         image_resize_linear_stride(
-            dst + offset,
+            dst + x_offset,
             new_width, dst_height,
             src, src_width, src_height, src_stride,
             dst_width
@@ -108,30 +149,32 @@ void image_center(
     const uint32_t bg_clear
 ) {
     // TODO: Optimize by only clearing the areas the image blit doesn't fill
-    for (uint32_t i = 0; i < dst_width * dst_height; ++i) {
-        dst[i] = bg_clear;
+    image_clear(dst, dst_width, dst_height, bg_clear);
+
+    if (dst_width == 0 || dst_height == 0 || src_width == 0 || src_height == 0) {
+        return;
     }
 
     if (src_height > dst_height) {
-        const int y_offset = (src_height - dst_height) / 2;
+        const uint32_t y_offset = (src_height - dst_height) / 2;
         uint32_t new_height = src_height - y_offset;
-        src += y_offset * src_stride;
+        src += (size_t)y_offset * (size_t)src_stride;
 
         if (new_height > dst_height)
             new_height = dst_height;
 
         if (src_width > dst_width) {
-            const int x_offset = (src_width - dst_width) / 2;
+            const uint32_t x_offset = (src_width - dst_width) / 2;
             src += x_offset;
 
-            for (uint32_t y = 0; y < dst_height; ++y) {
+            for (uint32_t y = 0; y < new_height; ++y) {
                 for (uint32_t x = 0; x < dst_width; ++x) {
                     *dst++ = *src++;
                 }
                 src += (src_stride - dst_width);
             }
         } else {
-            const int x_offset = (dst_width - src_width) / 2;
+            const uint32_t x_offset = (dst_width - src_width) / 2;
 
             for (uint32_t y = 0; y < new_height; ++y) {
                 dst += x_offset;
@@ -144,11 +187,11 @@ void image_center(
             }
         }
     } else {
-        const int y_offset = (dst_height - src_height) / 2;
-        dst += y_offset * dst_width;
+        const uint32_t y_offset = (dst_height - src_height) / 2;
+        dst += (size_t)y_offset * (size_t)dst_width;
 
         if (src_width > dst_width) {
-            const int x_offset = (src_width - dst_width) / 2;
+            const uint32_t x_offset = (src_width - dst_width) / 2;
             src += x_offset;
 
             for (uint32_t y = 0; y < src_height; ++y) {
@@ -158,7 +201,7 @@ void image_center(
                 src += (src_stride - dst_width);
             }
         } else {
-            const int x_offset = (dst_width - src_width) / 2;
+            const uint32_t x_offset = (dst_width - src_width) / 2;
             dst += x_offset;
 
             for (uint32_t y = 0; y < src_height; ++y) {
@@ -183,46 +226,22 @@ void image_upper_left(
     const uint32_t bg_clear
 ) {
     // TODO: Optimize by only clearing the areas the image blit doesn't fill
-    for (uint32_t i = 0; i < dst_width * dst_height; ++i) {
-        dst[i] = bg_clear;
+    image_clear(dst, dst_width, dst_height, bg_clear);
+
+    if (dst_width == 0 || dst_height == 0 || src_width == 0 || src_height == 0) {
+        return;
     }
 
-    if (src_height > dst_height) {
-        const int y_offset = (src_height - dst_height) / 2;
-        const uint32_t new_height = src_height - y_offset;
+    // Anchored top-left, so the visible region is simply the leading
+    // min(src, dst) rows and columns of the source.
+    const uint32_t copy_height = src_height < dst_height ? src_height : dst_height;
+    const uint32_t copy_width = src_width < dst_width ? src_width : dst_width;
 
-        if (src_width > dst_width) {
-            for (uint32_t y = 0; y < dst_height; ++y) {
-                for (uint32_t x = 0; x < dst_width; ++x) {
-                    *dst++ = *src++;
-                }
-                src += (src_stride - dst_width);
-            }
-        } else {
-            for (uint32_t y = 0; y < new_height; ++y) {
-                for (uint32_t x = 0; x < src_width; ++x) {
-                    *dst++ = *src++;
-                }
-                dst += (dst_width - src_width);
-                src += src_stride - src_width;
-            }
+    for (uint32_t y = 0; y < copy_height; ++y) {
+        for (uint32_t x = 0; x < copy_width; ++x) {
+            *dst++ = *src++;
         }
-    } else {
-        if (src_width > dst_width) {
-            for (uint32_t y = 0; y < src_height; ++y) {
-                for (uint32_t x = 0; x < dst_width; ++x) {
-                    *dst++ = *src++;
-                }
-                src += (src_stride - dst_width);
-            }
-        } else {
-            for (uint32_t y = 0; y < src_height; ++y) {
-                for (uint32_t x = 0; x < src_width; ++x) {
-                    *dst++ = *src++;
-                }
-                dst += (dst_width - src_width);
-                src += src_stride - src_width;
-            }
-        }
+        dst += (dst_width - copy_width);
+        src += (src_stride - copy_width);
     }
 }

--- a/src/os/posix/common.rs
+++ b/src/os/posix/common.rs
@@ -104,3 +104,155 @@ extern "C" {
         src_stride: u32,
     );
 }
+
+#[cfg(test)]
+mod scaler_tests {
+    use super::*;
+
+    /// The guard has to absorb the whole overrun, not just its first element:
+    /// an overrun that reaches past the allocation corrupts the heap and takes
+    /// the test binary down before the assertion runs. No scaler overruns by
+    /// more than the source size, so a source-sized guard bounds them all.
+    ///
+    /// Only write overruns are caught. An out-of-bounds *read* leaves the guard
+    /// intact and shows up as a wrong pixel value or a crash instead.
+    fn scale_guarded(
+        f: unsafe extern "C" fn(*mut u32, u32, u32, *const u32, u32, u32, u32, u32),
+        dst_width: usize,
+        dst_height: usize,
+        src_width: usize,
+        src_height: usize,
+    ) -> Vec<u32> {
+        const GUARD_VALUE: u32 = 0xdead_beef;
+
+        let src: Vec<u32> = (0..src_width * src_height).map(|i| i as u32 | 1).collect();
+        let visible = dst_width * dst_height;
+        let guard = src.len() + 64;
+        let mut dst = vec![GUARD_VALUE; visible + guard];
+
+        unsafe {
+            f(
+                dst.as_mut_ptr(),
+                dst_width as u32,
+                dst_height as u32,
+                src.as_ptr(),
+                src_width as u32,
+                src_height as u32,
+                src_width as u32,
+                0,
+            );
+        }
+
+        assert!(
+            dst[visible..].iter().all(|&v| v == GUARD_VALUE),
+            "scaler wrote past the end of the destination buffer ({}x{} dst, {}x{} src)",
+            dst_width,
+            dst_height,
+            src_width,
+            src_height
+        );
+
+        dst.truncate(visible);
+        dst
+    }
+
+    /// Reachable from safe code via `ScaleMode::UpperLeft`.
+    #[test]
+    fn upper_left_does_not_overflow_when_source_is_taller() {
+        for (dw, dh, sw, sh) in [(1, 1, 1, 2), (200, 100, 100, 300), (64, 16, 33, 100)] {
+            scale_guarded(image_upper_left, dw, dh, sw, sh);
+        }
+    }
+
+    /// Upper-left anchoring shows the top-left corner of the source, not a
+    /// vertically centered slice of it.
+    #[test]
+    fn upper_left_is_anchored_top_left() {
+        let dst = scale_guarded(image_upper_left, 2, 2, 2, 4);
+        assert_eq!(dst, vec![1, 1, 3, 3]);
+    }
+
+    #[test]
+    fn center_does_not_overflow() {
+        for (dw, dh, sw, sh) in [(1, 1, 2, 2), (100, 200, 300, 100), (33, 64, 100, 7)] {
+            scale_guarded(image_center, dw, dh, sw, sh);
+        }
+    }
+
+    #[test]
+    fn aspect_fill_centers_the_image() {
+        // 100x100 source (1:1) into a 300x100 window: pillarboxed, so the
+        // image should occupy the middle third.
+        let dst = scale_guarded(image_resize_linear_aspect_fill, 300, 100, 100, 100);
+        let row = &dst[50 * 300..51 * 300];
+        let first = row.iter().position(|&v| v != 0).unwrap();
+        let last = row.iter().rposition(|&v| v != 0).unwrap();
+        assert_eq!((first, last), (100, 199));
+
+        // 300x100 source (3:1) into a 300x300 window: letterboxed.
+        let dst = scale_guarded(image_resize_linear_aspect_fill, 300, 300, 300, 100);
+        let col: Vec<u32> = (0..300).map(|y| dst[y * 300 + 150]).collect();
+        let first = col.iter().position(|&v| v != 0).unwrap();
+        let last = col.iter().rposition(|&v| v != 0).unwrap();
+        assert_eq!((first, last), (100, 199));
+    }
+
+    /// A source dimension above 2^21 overflows a 32-bit 10.10 accumulator.
+    /// Such a buffer passes `check_buffer_size` (2.2M x 1 is 8.8 MB).
+    #[test]
+    fn resize_linear_handles_large_source_dimensions() {
+        let width = 2_200_000usize;
+        let src = vec![7u32; width];
+        let mut dst = vec![0u32; 100 * 100];
+
+        unsafe {
+            image_resize_linear(
+                dst.as_mut_ptr(),
+                100,
+                100,
+                src.as_ptr(),
+                width as u32,
+                1,
+                width as u32,
+            );
+        }
+
+        assert!(dst.iter().all(|&v| v == 7));
+    }
+
+    /// The pillarbox branch routes through a second copy of the resize loop
+    /// with its own accumulators. Overflowing them needs a source dimension
+    /// above 2^21 *and* a destination tall enough for the loop to reach the
+    /// overflowing iteration -- a short destination scales the source down to
+    /// a zero-width blit that never indexes it.
+    #[test]
+    fn aspect_fill_handles_large_source_dimensions() {
+        let tall = 2_100_000usize;
+        let dst = scale_guarded(image_resize_linear_aspect_fill, 2, tall, 1, tall);
+
+        // One source column, centered: column 0 is the blit, column 1 is
+        // background. Row y maps to source row y at this ratio.
+        for y in [0, tall / 2, 2_097_151, 2_097_152, tall - 1] {
+            assert_eq!(
+                dst[y * 2],
+                y as u32 | 1,
+                "row {} came from outside the source",
+                y
+            );
+        }
+    }
+
+    #[test]
+    fn scalers_accept_degenerate_sizes() {
+        let src = [1u32, 2, 3, 4];
+        let mut dst = [0u32; 4];
+
+        unsafe {
+            image_resize_linear(dst.as_mut_ptr(), 0, 0, src.as_ptr(), 2, 2, 2);
+            image_resize_linear(dst.as_mut_ptr(), 2, 2, src.as_ptr(), 0, 0, 0);
+            image_resize_linear_aspect_fill(dst.as_mut_ptr(), 2, 2, src.as_ptr(), 0, 0, 0, 0);
+            image_center(dst.as_mut_ptr(), 2, 2, src.as_ptr(), 0, 0, 0, 0);
+            image_upper_left(dst.as_mut_ptr(), 2, 2, src.as_ptr(), 0, 0, 0, 0);
+        }
+    }
+}


### PR DESCRIPTION
Four audit findings, each reproduced locally before the fix and covered by a regression test.

Closes #406
Closes #407
Closes #422
Closes #424

### Changes

- **#406** `image_upper_left` looped over `src_height - (src_height - dst_height) / 2` rows into a `dst_height` buffer. Heap out-of-bounds write, reachable from safe code via `ScaleMode::UpperLeft`. Confirmed under ASan and as a glibc abort in a live Wayland window.
- **#407** Fixed-point coordinates accumulated in a 32-bit `int` wrapped negative for source dimensions above 2^21 (a 2.2M x 1 buffer passes `check_buffer_size`), and the aspect-fill offsets were computed as `(a - b) / -2` in unsigned arithmetic, so the image rendered top-left aligned instead of centered.
- **#422** `f32::clamp` asserts `min <= max`, so a scale-divided window size below one pixel aborted.
- **#424** `Key` had no `repr`, so the `transmute::<u8, Key>` in `key_handler` relied on unspecified layout.

Also fixes a build-script bug found while verifying: `cc` emits no `cargo:rerun-if-changed`, so cargo kept stale objects when only the C sources changed. Without it the scaler tests silently ran against the previous build.

### Verification

`cargo test` on Linux/Wayland, plus an x11-only build. The four scaler and key tests fail against the pre-fix `scalar.c` and pass after.

Note: #355 (the reported `AspectRatioStretch` segfault) was already fixed by d62b0f5 and can be closed separately.