### PR TITLE
Port Wayland backend to wayland-rs 0.31/0.32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,12 +77,15 @@ wayland = [
 ]
 
 [target.'cfg(not(any(target_os = "macos", target_os = "redox", windows, target_arch="wasm32")))'.dependencies]
-wayland-client = { version = "0.29", optional = true }
-wayland-protocols = { version = "0.29", features = [
+# `system` selects the libwayland-backed backend rather than wayland-rs'
+# pure-Rust one. It is required because `raw-window-handle` has to hand out a
+# real `wl_surface*`/`wl_display*`, which only that backend can produce.
+wayland-client = { version = "0.31", features = ["system"], optional = true }
+wayland-protocols = { version = "0.32", features = [
   "client",
-  "unstable_protocols",
+  "unstable",
 ], optional = true }
-wayland-cursor = { version = "0.29", optional = true }
+wayland-cursor = { version = "0.31", optional = true }
 tempfile = { version = "3.3", optional = true }
 x11-dl = { version = "2.19.1", optional = true }
 libc = { version = "0.2.107", optional = true }

--- a/src/os/posix/wayland.rs
+++ b/src/os/posix/wayland.rs
@@ -635,7 +635,7 @@ impl Window {
 
         let size = SurfaceSize::scaled(width, height, scale).ok_or_else(|| {
             Error::WindowCreate(format!(
-                "{}x{} at {}x scale is too large",
+                "{}x{} at {}x scale is not a usable window size",
                 width, height, scale
             ))
         })?;

--- a/src/os/posix/wayland.rs
+++ b/src/os/posix/wayland.rs
@@ -68,36 +68,65 @@ const KEY_MOUSE_BTN3: u32 = 274;
 const KEY_MOUSE_BTN8: u32 = 275;
 const KEY_MOUSE_BTN9: u32 = 276;
 
-/// Byte count of a `width` x `height` ARGB framebuffer, or `None` if the
-/// dimensions are not positive or the total does not fit the `i32` a
-/// `wl_shm_pool` size is sent as. Every path that accepts a size — window
-/// creation, a compositor configure, and the pool itself — goes through this,
-/// so `width * height` can never overflow downstream.
-fn framebuffer_bytes(width: i32, height: i32) -> Option<i32> {
-    if width <= 0 || height <= 0 {
-        return None;
-    }
-    i64::from(width)
-        .checked_mul(i64::from(height))
-        .and_then(|px| px.checked_mul(std::mem::size_of::<u32>() as i64))
-        .and_then(|bytes| i32::try_from(bytes).ok())
+/// A surface size with both axes positive and an ARGB byte count that fits the
+/// `i32` a `wl_shm_pool` size is sent as. `new` is the only constructor, so
+/// nothing downstream re-validates.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+struct SurfaceSize {
+    width: i32,
+    height: i32,
+    bytes: i32,
 }
 
-/// Which slot `BufferPool::get_buffer` should draw from.
+impl SurfaceSize {
+    fn new(width: i32, height: i32) -> Option<Self> {
+        if width <= 0 || height <= 0 {
+            return None;
+        }
+        let bytes = i64::from(width)
+            .checked_mul(i64::from(height))
+            .and_then(|px| px.checked_mul(std::mem::size_of::<u32>() as i64))
+            .and_then(|bytes| i32::try_from(bytes).ok())?;
+        Some(Self {
+            width,
+            height,
+            bytes,
+        })
+    }
+
+    fn scaled(width: usize, height: usize, scale: i32) -> Option<Self> {
+        let axis = |v: usize| i32::try_from(v).ok()?.checked_mul(scale);
+        Self::new(axis(width)?, axis(height)?)
+    }
+
+    /// A zero axis in an `xdg_toplevel::configure` means the compositor is
+    /// leaving that dimension to us, so the current value stands.
+    fn reconfigured(self, width: i32, height: i32) -> Option<Self> {
+        Self::new(
+            if width == 0 { self.width } else { width },
+            if height == 0 { self.height } else { height },
+        )
+    }
+
+    /// Cannot overflow: the whole buffer already fits an i32.
+    fn stride(self) -> i32 {
+        self.width * std::mem::size_of::<u32>() as i32
+    }
+
+    fn pixels(self) -> usize {
+        self.width as usize * self.height as usize
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 enum Slot {
-    /// Reuse the released buffer at this index.
     Reuse(usize),
-    /// Nothing is free and the pool is under the cap: append a new buffer.
     Grow,
-    /// Every buffer is still held by the compositor and the pool is at its
-    /// cap. There is nothing safe to write to: the frame has to be dropped.
+    /// Every buffer is still held and the pool is at its cap; drop the frame.
     Wait,
 }
 
-/// Picks the slot to draw from, given which buffers the compositor has
-/// released. Split out from `get_buffer` so the policy can be tested without
-/// a compositor.
+/// Split out of `get_buffer` so the policy is testable without a compositor.
 fn select_slot(released: &[bool], max: usize) -> Slot {
     match released.iter().position(|&r| r) {
         Some(idx) => Slot::Reuse(idx),
@@ -106,10 +135,8 @@ fn select_slot(released: &[bool], max: usize) -> Slot {
     }
 }
 
-/// Upper bound on how many shm buffers the pool will grow to. Past it, a frame
-/// with no released buffer to write into is dropped rather than presented. A
-/// well-behaved compositor releases buffers promptly and the pool settles at
-/// two; the cap only stops a misbehaving one from growing it without bound.
+/// Past this, a frame with no released buffer to write into is dropped rather
+/// than presented. A well-behaved compositor settles the pool at two.
 const MAX_POOLED_BUFFERS: usize = 4;
 
 struct Buffer {
@@ -120,7 +147,7 @@ struct Buffer {
     /// Set by the compositor's `wl_buffer::Release`, cleared when we attach the
     /// buffer to the surface. Only a released buffer may be written to.
     released: Arc<AtomicBool>,
-    fb_size: (i32, i32),
+    fb_size: SurfaceSize,
 }
 
 struct BufferPool {
@@ -140,19 +167,19 @@ impl BufferPool {
 
     fn create_shm_buffer(
         shm_pool: &WlShmPool,
-        size: (i32, i32),
+        size: SurfaceSize,
         format: Format,
         qh: &QueueHandle<WaylandState>,
     ) -> (WlBuffer, Arc<AtomicBool>) {
-        // The flag doubles as the buffer's dispatch user data, so the release
-        // event lands on it directly without having to search the pool.
+        // Doubles as the buffer's dispatch user data, so a release lands on it
+        // directly without searching the pool.
         let released = Arc::new(AtomicBool::new(true));
 
         let buffer = shm_pool.create_buffer(
             0,
-            size.0,
-            size.1,
-            size.0 * std::mem::size_of::<u32>() as i32,
+            size.width,
+            size.height,
+            size.stride(),
             format,
             qh,
             released.clone(),
@@ -161,23 +188,14 @@ impl BufferPool {
         (buffer, released)
     }
 
-    /// Returns a buffer the compositor is not currently reading from, growing
-    /// the pool if every existing one is still in use.
-    ///
-    /// `Ok(None)` means every buffer is still held and the pool is at its cap.
-    /// The caller must drop the frame rather than write to a held buffer,
-    /// which would leave the surface contents undefined.
+    /// `Ok(None)` means every buffer is still held and the pool is at its cap;
+    /// the caller must drop the frame rather than write to a held buffer.
     fn get_buffer(
         &mut self,
-        size: (i32, i32),
+        size: SurfaceSize,
         qh: &QueueHandle<WaylandState>,
     ) -> std::io::Result<Option<(&mut File, &WlBuffer)>> {
-        let size_bytes = framebuffer_bytes(size.0, size.1).ok_or_else(|| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!("surface {}x{} is too large for an shm pool", size.0, size.1),
-            )
-        })?;
+        let size_bytes = size.bytes;
 
         let released: Vec<bool> = self
             .pool
@@ -190,9 +208,8 @@ impl BufferPool {
             Slot::Wait => return Ok(None),
             Slot::Grow => {
                 let file = tempfile::tempfile()?;
-                // The compositor mmaps the pool as soon as it is created, so
-                // the file has to be that large before it is handed over --
-                // touching a mapping that extends past EOF is a SIGBUS.
+                // The compositor mmaps the pool on creation; a mapping past
+                // EOF is a SIGBUS.
                 file.set_len(size_bytes as u64)?;
                 let shm_pool = self.shm.create_pool(file.as_fd(), size_bytes, qh, ());
                 let (buffer, released) = Self::create_shm_buffer(&shm_pool, size, self.format, qh);
@@ -212,8 +229,7 @@ impl BufferPool {
 
         let entry = &mut self.pool[idx];
 
-        // A wl_shm_pool may only ever grow. Extend the backing file first,
-        // for the same reason it is sized up front on creation.
+        // A wl_shm_pool may only grow, and the file has to lead it.
         if size_bytes > entry.pool_size {
             entry.file.set_len(size_bytes as u64)?;
             entry.pool.resize(size_bytes);
@@ -231,8 +247,6 @@ impl BufferPool {
         Ok(Some((&mut entry.file, &entry.buffer)))
     }
 
-    /// Marks `buffer` as in use by the compositor. Called at attach time; the
-    /// matching `Release` event clears it again.
     fn mark_attached(&self, buffer: &WlBuffer) {
         if let Some(entry) = self.pool.iter().find(|e| &e.buffer == buffer) {
             entry.released.store(false, Ordering::Release);
@@ -383,7 +397,11 @@ struct DisplayInfo {
 impl DisplayInfo {
     /// Accepts the size of the surface to be created, whether or not the alpha channel will be
     /// rendered, and whether or not server-side decorations will be used.
-    fn new(size: (i32, i32), alpha: bool, decorate: bool) -> Result<(Self, WlKeyboard, WlPointer)> {
+    fn new(
+        size: SurfaceSize,
+        alpha: bool,
+        decorate: bool,
+    ) -> Result<(Self, WlKeyboard, WlPointer)> {
         let conn = Connection::connect_to_env().map_err(|e| {
             Error::WindowCreate(format!("Failed to connect to the Wayland display: {:?}", e))
         })?;
@@ -419,8 +437,6 @@ impl DisplayInfo {
         };
 
         let mut buf_pool = BufferPool::new(shm.clone(), format);
-        // The pool is empty here, so this always allocates rather than
-        // returning `None` for want of a free buffer.
         let (file, buffer) = buf_pool
             .get_buffer(size, &qh)
             .map_err(|e| Error::WindowCreate(format!("Failed to retrieve Buffer: {:?}", e)))?
@@ -428,7 +444,7 @@ impl DisplayInfo {
         let buffer = buffer.clone();
 
         // Add a black canvas into the framebuffer
-        let frame: Vec<u32> = vec![0xFF00_0000; (size.0 * size.1) as usize];
+        let frame: Vec<u32> = vec![0xFF00_0000; size.pixels()];
         let slice = unsafe {
             std::slice::from_raw_parts(
                 frame.as_ptr() as *const u8,
@@ -508,9 +524,9 @@ impl DisplayInfo {
     }
 
     #[inline]
-    fn set_no_resize(&self, size: (i32, i32)) {
-        self.toplevel.set_max_size(size.0, size.1);
-        self.toplevel.set_min_size(size.0, size.1);
+    fn set_no_resize(&self, size: SurfaceSize) {
+        self.toplevel.set_max_size(size.width, size.height);
+        self.toplevel.set_min_size(size.width, size.height);
     }
 
     // Sets a specific cursor style
@@ -527,7 +543,7 @@ impl DisplayInfo {
     }
 
     // Resizes when buffer is bigger or less
-    fn update_framebuffer(&mut self, buffer: &[u32], size: (i32, i32)) -> std::io::Result<()> {
+    fn update_framebuffer(&mut self, buffer: &[u32], size: SurfaceSize) -> std::io::Result<()> {
         // Every buffer is still held by the compositor: drop this frame
         // rather than write into one it may be scanning out. The previous
         // frame stays on screen and the next call presents normally.
@@ -563,8 +579,7 @@ impl DisplayInfo {
 pub struct Window {
     display: DisplayInfo,
 
-    width: i32,
-    height: i32,
+    size: SurfaceSize,
 
     scale: i32,
     bg_color: u32,
@@ -618,38 +633,21 @@ impl Window {
             Scale::X32 => 32,
         };
 
-        // `Scale::X32` on a large request can overflow an i32 here, which
-        // would reach the compositor as a nonsensical surface size.
-        let scaled = |v: usize| -> Result<i32> {
-            i32::try_from(v)
-                .ok()
-                .and_then(|v: i32| v.checked_mul(scale))
-                .ok_or_else(|| {
-                    Error::WindowCreate(format!(
-                        "{}x{} at {}x scale is too large",
-                        width, height, scale
-                    ))
-                })
-        };
-        let (scaled_width, scaled_height) = (scaled(width)?, scaled(height)?);
-        if framebuffer_bytes(scaled_width, scaled_height).is_none() {
-            return Err(Error::WindowCreate(format!(
+        let size = SurfaceSize::scaled(width, height, scale).ok_or_else(|| {
+            Error::WindowCreate(format!(
                 "{}x{} at {}x scale is too large",
                 width, height, scale
-            )));
-        }
+            ))
+        })?;
 
-        let (display, keyboard, pointer) = DisplayInfo::new(
-            (scaled_width, scaled_height),
-            opts.transparency,
-            !opts.borderless || opts.none,
-        )?;
+        let (display, keyboard, pointer) =
+            DisplayInfo::new(size, opts.transparency, !opts.borderless || opts.none)?;
 
         if opts.title {
             display.set_title(name);
         }
         if !opts.resize || opts.none {
-            display.set_no_resize((scaled_width, scaled_height));
+            display.set_no_resize(size);
         }
 
         #[cfg(feature = "dlopen")]
@@ -676,8 +674,7 @@ impl Window {
         Ok(Self {
             display,
 
-            width: scaled_width,
-            height: scaled_height,
+            size,
 
             scale,
             bg_color: 0,
@@ -738,7 +735,7 @@ impl Window {
 
     #[inline]
     pub fn get_size(&self) -> (usize, usize) {
-        (self.width as usize, self.height as usize)
+        (self.size.width as usize, self.size.height as usize)
     }
 
     #[inline]
@@ -762,8 +759,8 @@ impl Window {
             self.mouse_x,
             self.mouse_y,
             self.scale as f32,
-            self.width as f32,
-            self.height as f32,
+            self.size.width as f32,
+            self.size.height as f32,
         )
     }
 
@@ -784,8 +781,8 @@ impl Window {
             self.mouse_x,
             self.mouse_y,
             1.0,
-            self.width as f32,
-            self.height as f32,
+            self.size.width as f32,
+            self.size.height as f32,
         )
     }
 
@@ -806,7 +803,7 @@ impl Window {
     #[inline]
     pub fn set_position(&mut self, x: isize, y: isize) {
         self.display
-            .set_geometry((x as i32, y as i32), (self.width, self.height));
+            .set_geometry((x as i32, y as i32), (self.size.width, self.size.height));
     }
 
     #[inline]
@@ -939,14 +936,9 @@ impl Window {
 
         if let Some((width, height)) = self.display.state.resolution.take() {
             if self.resizable {
-                // The compositor picks these, so a size the framebuffer maths
-                // cannot represent has to be refused rather than stored; 0x0
-                // is the normal "you choose" configure.
-                if framebuffer_bytes(width, height).is_some() {
-                    self.width = width;
-                    self.height = height;
-                } else if (width, height) != (0, 0) {
-                    eprintln!("Ignoring unusable configure size {}x{}", width, height);
+                match self.size.reconfigured(width, height) {
+                    Some(size) => self.size = size,
+                    None => eprintln!("Ignoring unusable configure size {}x{}", width, height),
                 }
             }
         }
@@ -1064,7 +1056,13 @@ impl Window {
                 } => {
                     use wayland_client::protocol::wl_pointer::ButtonState;
 
-                    let pressed = matches!(state, WEnum::Value(ButtonState::Pressed));
+                    // An unknown state is not a release; treating it as one
+                    // would clear a button still being held.
+                    let pressed = match state {
+                        WEnum::Value(ButtonState::Pressed) => true,
+                        WEnum::Value(ButtonState::Released) => false,
+                        _ => continue,
+                    };
 
                     match button {
                         // Left mouse button
@@ -1416,7 +1414,7 @@ impl Window {
             check_buffer_size(buffer, buf_width, buf_height, buf_stride)?;
             unsafe { self.scale_buffer(buffer, buf_width, buf_height, buf_stride) };
             self.display
-                .update_framebuffer(&self.buffer, (self.width, self.height))
+                .update_framebuffer(&self.buffer, self.size)
                 .map_err(|e| Error::UpdateFailed(format!("Error updating framebuffer: {:?}", e)))
         })();
 
@@ -1441,14 +1439,14 @@ impl Window {
         buf_height: usize,
         buf_stride: usize,
     ) {
-        self.buffer.resize((self.width * self.height) as usize, 0);
+        self.buffer.resize(self.size.pixels(), 0);
 
         match self.scale_mode {
             ScaleMode::Stretch => {
                 image_resize_linear(
                     self.buffer.as_mut_ptr(),
-                    self.width as u32,
-                    self.height as u32,
+                    self.size.width as u32,
+                    self.size.height as u32,
                     buffer.as_ptr(),
                     buf_width as u32,
                     buf_height as u32,
@@ -1459,8 +1457,8 @@ impl Window {
             ScaleMode::AspectRatioStretch => {
                 image_resize_linear_aspect_fill(
                     self.buffer.as_mut_ptr(),
-                    self.width as u32,
-                    self.height as u32,
+                    self.size.width as u32,
+                    self.size.height as u32,
                     buffer.as_ptr(),
                     buf_width as u32,
                     buf_height as u32,
@@ -1472,8 +1470,8 @@ impl Window {
             ScaleMode::Center => {
                 image_center(
                     self.buffer.as_mut_ptr(),
-                    self.width as u32,
-                    self.height as u32,
+                    self.size.width as u32,
+                    self.size.height as u32,
                     buffer.as_ptr(),
                     buf_width as u32,
                     buf_height as u32,
@@ -1485,8 +1483,8 @@ impl Window {
             ScaleMode::UpperLeft => {
                 image_upper_left(
                     self.buffer.as_mut_ptr(),
-                    self.width as u32,
-                    self.height as u32,
+                    self.size.width as u32,
+                    self.size.height as u32,
                     buffer.as_ptr(),
                     buf_width as u32,
                     buf_height as u32,
@@ -1888,32 +1886,61 @@ xkb_symbols "minifb_test" {
 
 #[cfg(test)]
 mod buffer_pool_tests {
-    use super::{framebuffer_bytes, select_slot, Slot, MAX_POOLED_BUFFERS};
+    use super::{select_slot, Slot, SurfaceSize, MAX_POOLED_BUFFERS};
 
-    #[test]
-    fn framebuffer_bytes_is_width_times_height_times_four() {
-        assert_eq!(framebuffer_bytes(640, 480), Some(640 * 480 * 4));
+    fn size(w: i32, h: i32) -> SurfaceSize {
+        SurfaceSize::new(w, h).unwrap()
     }
 
     #[test]
-    fn framebuffer_bytes_rejects_non_positive() {
-        assert_eq!(framebuffer_bytes(0, 480), None);
-        assert_eq!(framebuffer_bytes(640, 0), None);
-        assert_eq!(framebuffer_bytes(-1, 480), None);
-        assert_eq!(framebuffer_bytes(640, -1), None);
+    fn byte_count_is_width_times_height_times_four() {
+        assert_eq!(size(640, 480).bytes, 640 * 480 * 4);
+        assert_eq!(size(640, 480).stride(), 640 * 4);
+        assert_eq!(size(640, 480).pixels(), 640 * 480);
+    }
+
+    #[test]
+    fn non_positive_dimensions_are_rejected() {
+        assert_eq!(SurfaceSize::new(0, 480), None);
+        assert_eq!(SurfaceSize::new(640, 0), None);
+        assert_eq!(SurfaceSize::new(-1, 480), None);
+        assert_eq!(SurfaceSize::new(640, -1), None);
     }
 
     /// `i32::MAX * i32::MAX * 4` exceeds `i64::MAX`, so the intermediate
     /// product has to be checked, not just the final narrowing to i32.
     #[test]
-    fn framebuffer_bytes_survives_the_largest_dimensions() {
-        assert_eq!(framebuffer_bytes(i32::MAX, i32::MAX), None);
+    fn the_largest_dimensions_do_not_overflow_the_check() {
+        assert_eq!(SurfaceSize::new(i32::MAX, i32::MAX), None);
     }
 
     #[test]
-    fn framebuffer_bytes_rejects_a_total_larger_than_i32() {
+    fn a_total_larger_than_i32_is_rejected() {
         // Dimensions are individually fine; the byte count is not.
-        assert_eq!(framebuffer_bytes(40_000, 40_000), None);
+        assert_eq!(SurfaceSize::new(40_000, 40_000), None);
+    }
+
+    #[test]
+    fn scale_multiply_is_checked() {
+        assert_eq!(SurfaceSize::scaled(320, 240, 2), SurfaceSize::new(640, 480));
+        assert_eq!(SurfaceSize::scaled(usize::MAX, 240, 1), None);
+        assert_eq!(SurfaceSize::scaled(i32::MAX as usize, 1, 32), None);
+    }
+
+    #[test]
+    fn a_zero_configure_axis_keeps_the_current_value() {
+        let current = size(640, 480);
+        assert_eq!(current.reconfigured(0, 600), SurfaceSize::new(640, 600));
+        assert_eq!(current.reconfigured(800, 0), SurfaceSize::new(800, 480));
+        assert_eq!(current.reconfigured(0, 0), Some(current));
+        assert_eq!(current.reconfigured(800, 600), SurfaceSize::new(800, 600));
+    }
+
+    #[test]
+    fn an_unusable_configure_is_rejected() {
+        let current = size(640, 480);
+        assert_eq!(current.reconfigured(-1, 600), None);
+        assert_eq!(current.reconfigured(40_000, 40_000), None);
     }
 
     #[test]

--- a/src/os/posix/wayland.rs
+++ b/src/os/posix/wayland.rs
@@ -977,12 +977,19 @@ impl Window {
                     self.active = false;
                 }
                 Event::Key { key, state, .. } => {
+                    // `key` is compositor-supplied, so the offset to xkb's
+                    // numbering must not wrap into a valid-looking keycode.
+                    let key = match key.checked_add(KEY_XKB_OFFSET) {
+                        Some(key) => key,
+                        None => continue,
+                    };
+
                     if !self.xkb_state.is_null() && !self.xkb_keymap.is_null() {
                         if let WEnum::Value(state) = state {
                             Self::handle_key(
                                 self.xkb_keymap,
                                 self.xkb_state,
-                                key + KEY_XKB_OFFSET,
+                                key,
                                 state,
                                 &mut self.key_handler,
                                 &mut self.held,
@@ -1336,6 +1343,23 @@ impl Window {
         match keymap {
             WEnum::Value(KeymapFormat::XkbV1) => {
                 unsafe {
+                    // mmap does not check `len` against the file, so a short
+                    // fd would map fine and then fault when xkbcommon read it.
+                    let mut stat: libc::stat = std::mem::zeroed();
+                    if libc::fstat(fd.as_raw_fd(), &mut stat) != 0 {
+                        return Err(Error::WindowCreate(format!(
+                            "Could not stat the keymap from the compositor ({})",
+                            std::io::Error::last_os_error()
+                        )));
+                    }
+                    let file_len = stat.st_size;
+                    if len == 0 || file_len < 0 || (file_len as u64) < u64::from(len) {
+                        return Err(Error::WindowCreate(format!(
+                            "Compositor sent a {} byte keymap backed by {} bytes",
+                            len, file_len
+                        )));
+                    }
+
                     // The file descriptor must be memory-mapped (with MAP_PRIVATE).
                     let addr = libc::mmap(
                         std::ptr::null_mut(),
@@ -1350,6 +1374,15 @@ impl Window {
                             "Could not mmap keymap from compositor ({})",
                             std::io::Error::last_os_error()
                         )));
+                    }
+
+                    // `len` counts the terminator, and the parser below scans
+                    // for one; without it the scan runs past the mapping.
+                    if *(addr as *const u8).add(len as usize - 1) != 0 {
+                        libc::munmap(addr, len as usize);
+                        return Err(Error::WindowCreate(
+                            "Compositor sent an unterminated keymap.".to_owned(),
+                        ));
                     }
 
                     let keymap = ffi_dispatch!(

--- a/src/os/posix/wayland.rs
+++ b/src/os/posix/wayland.rs
@@ -263,7 +263,11 @@ struct WaylandState {
     /// Latest unacknowledged `xdg_surface::Configure` serial. Acknowledged when
     /// the next frame is presented, so the ack is paired with actual content.
     xdg_config: Option<u32>,
-    /// Latest `xdg_toplevel::Configure` size.
+    /// Size from an `xdg_toplevel::Configure` that no `xdg_surface::Configure`
+    /// has closed yet, so it is not part of a configure transaction and must
+    /// not be applied.
+    pending_resolution: Option<(i32, i32)>,
+    /// Size of the most recent complete configure transaction.
     resolution: Option<(i32, i32)>,
     closed: bool,
 }
@@ -345,8 +349,13 @@ impl Dispatch<XdgSurface, ()> for WaylandState {
         _: &Connection,
         _: &QueueHandle<Self>,
     ) {
-        // Only the most recent configure needs acknowledging.
+        // Ends a configure sequence, so it is what seals the size the
+        // preceding xdg_toplevel::Configure proposed; publishing that earlier
+        // lets a frame carry one transaction's size under another's serial.
         if let xdg_surface::Event::Configure { serial } = event {
+            if let Some(size) = state.pending_resolution.take() {
+                state.resolution = Some(size);
+            }
             state.xdg_config = Some(serial);
         }
     }
@@ -363,7 +372,7 @@ impl Dispatch<XdgToplevel, ()> for WaylandState {
     ) {
         match event {
             xdg_toplevel::Event::Configure { width, height, .. } => {
-                state.resolution = Some((width, height));
+                state.pending_resolution = Some((width, height));
             }
             xdg_toplevel::Event::Close => {
                 state.closed = true;
@@ -967,7 +976,21 @@ impl Window {
                             self.xkb_keymap = keymap;
                             self.xkb_state = unsafe { ffi_dispatch!(XKBH, xkb_state_new, keymap) };
                         }
-                        Err(e) => eprintln!("Failed to load the compositor keymap: {:?}", e),
+                        Err(e) => {
+                            eprintln!("Failed to load the compositor keymap: {:?}", e);
+                            // A keycode means nothing without the layout it
+                            // came with, so translation stops here rather
+                            // than continuing against the withdrawn one --
+                            // which also means no release will arrive for a
+                            // key held across this point.
+                            unsafe {
+                                ffi_dispatch!(XKBH, xkb_state_unref, self.xkb_state);
+                                ffi_dispatch!(XKBH, xkb_keymap_unref, self.xkb_keymap);
+                            }
+                            self.xkb_state = std::ptr::null_mut();
+                            self.xkb_keymap = std::ptr::null_mut();
+                            self.release_held_keys();
+                        }
                     }
                 }
                 Event::Enter { .. } => {
@@ -1112,6 +1135,15 @@ impl Window {
                     self.apply_cursor(serial);
                 }
                 _ => {}
+            }
+        }
+    }
+
+    /// Clears every key this window still believes is down.
+    fn release_held_keys(&mut self) {
+        for slot in self.held.iter_mut() {
+            if let Some(key) = slot.take() {
+                self.key_handler.set_key_state(key, false);
             }
         }
     }

--- a/src/os/posix/wayland.rs
+++ b/src/os/posix/wayland.rs
@@ -1,12 +1,14 @@
 use std::{
-    cell::RefCell,
+    convert::TryFrom,
     ffi::c_void,
     fs::File,
     io::{Seek, SeekFrom, Write},
-    os::unix::io::{AsRawFd, RawFd},
+    os::unix::io::{AsFd, AsRawFd, OwnedFd},
     ptr::NonNull,
-    rc::Rc,
-    sync::mpsc,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
     time::Duration,
 };
 
@@ -23,23 +25,31 @@ use raw_window_handle::{
     RawWindowHandle, WaylandDisplayHandle, WaylandWindowHandle, WindowHandle,
 };
 use wayland_client::{
+    backend::WaylandError,
+    delegate_noop,
+    globals::{registry_queue_init, GlobalList, GlobalListContents},
     protocol::{
-        wl_buffer::WlBuffer,
+        wl_buffer::{self, WlBuffer},
         wl_compositor::WlCompositor,
-        wl_display::WlDisplay,
         wl_keyboard::{self, KeymapFormat, WlKeyboard},
         wl_pointer::{self, WlPointer},
+        wl_registry::WlRegistry,
         wl_seat::WlSeat,
         wl_shm::{Format, WlShm},
         wl_shm_pool::WlShmPool,
         wl_surface::WlSurface,
     },
-    Attached, Display, EventQueue, GlobalManager, Main,
+    Connection, Dispatch, EventQueue, Proxy, QueueHandle, WEnum,
 };
-use wayland_protocols::{
-    unstable::xdg_decoration::v1::client::zxdg_decoration_manager_v1::ZxdgDecorationManagerV1,
-    xdg_shell::client::{
-        xdg_surface::XdgSurface, xdg_toplevel::XdgToplevel, xdg_wm_base::XdgWmBase,
+use wayland_protocols::xdg::{
+    decoration::zv1::client::{
+        zxdg_decoration_manager_v1::ZxdgDecorationManagerV1,
+        zxdg_toplevel_decoration_v1::ZxdgToplevelDecorationV1,
+    },
+    shell::client::{
+        xdg_surface::{self, XdgSurface},
+        xdg_toplevel::{self, XdgToplevel},
+        xdg_wm_base::{self, XdgWmBase},
     },
 };
 
@@ -58,26 +68,54 @@ const KEY_MOUSE_BTN3: u32 = 274;
 const KEY_MOUSE_BTN8: u32 = 275;
 const KEY_MOUSE_BTN9: u32 = 276;
 
-type ToplevelResolution = Rc<RefCell<Option<(i32, i32)>>>;
-type ToplevelClosed = Rc<RefCell<bool>>;
+/// Which slot `BufferPool::get_buffer` should draw from.
+#[derive(Debug, PartialEq, Eq)]
+enum Slot {
+    /// Reuse the released buffer at this index.
+    Reuse(usize),
+    /// Nothing is free and the pool is under the cap: append a new buffer.
+    Grow,
+    /// Every buffer is still held by the compositor and the pool is at its
+    /// cap. There is nothing safe to write to: the frame has to be dropped.
+    Wait,
+}
+
+/// Picks the slot to draw from, given which buffers the compositor has
+/// released. Split out from `get_buffer` so the policy can be tested without
+/// a compositor.
+fn select_slot(released: &[bool], max: usize) -> Slot {
+    match released.iter().position(|&r| r) {
+        Some(idx) => Slot::Reuse(idx),
+        None if released.len() < max => Slot::Grow,
+        None => Slot::Wait,
+    }
+}
+
+/// Upper bound on how many shm buffers the pool will grow to. Past it, a frame
+/// with no released buffer to write into is dropped rather than presented. A
+/// well-behaved compositor releases buffers promptly and the pool settles at
+/// two; the cap only stops a misbehaving one from growing it without bound.
+const MAX_POOLED_BUFFERS: usize = 4;
 
 struct Buffer {
-    fd: File,
-    pool: Main<WlShmPool>,
+    file: File,
+    pool: WlShmPool,
     pool_size: i32,
-    buffer: Main<WlBuffer>,
-    buffer_state: Rc<RefCell<bool>>,
+    buffer: WlBuffer,
+    /// Set by the compositor's `wl_buffer::Release`, cleared when we attach the
+    /// buffer to the surface. Only a released buffer may be written to.
+    released: Arc<AtomicBool>,
     fb_size: (i32, i32),
 }
 
 struct BufferPool {
     pool: Vec<Buffer>,
-    shm: Main<WlShm>,
+    shm: WlShm,
     format: Format,
 }
 
 impl BufferPool {
-    fn new(shm: Main<WlShm>, format: Format) -> Self {
+    fn new(shm: WlShm, format: Format) -> Self {
         Self {
             pool: Vec::new(),
             shm,
@@ -86,138 +124,297 @@ impl BufferPool {
     }
 
     fn create_shm_buffer(
-        shm_pool: &Main<WlShmPool>,
+        shm_pool: &WlShmPool,
         size: (i32, i32),
         format: Format,
-    ) -> (Main<WlBuffer>, Rc<RefCell<bool>>) {
-        let buf = shm_pool.create_buffer(
+        qh: &QueueHandle<WaylandState>,
+    ) -> (WlBuffer, Arc<AtomicBool>) {
+        // The flag doubles as the buffer's dispatch user data, so the release
+        // event lands on it directly without having to search the pool.
+        let released = Arc::new(AtomicBool::new(true));
+
+        let buffer = shm_pool.create_buffer(
             0,
             size.0,
             size.1,
             size.0 * std::mem::size_of::<u32>() as i32,
             format,
+            qh,
+            released.clone(),
         );
 
-        // Whether or not the buffer has been released by the compositor
-        let buf_released = Rc::new(RefCell::new(false));
-        let buf_released_clone = buf_released.clone();
-
-        buf.quick_assign(move |_, event, _| {
-            use wayland_client::protocol::wl_buffer::Event;
-
-            if let Event::Release = event {
-                *buf_released_clone.borrow_mut() = true;
-            }
-        });
-
-        (buf, buf_released)
+        (buffer, released)
     }
 
-    fn get_buffer(&mut self, size: (i32, i32)) -> std::io::Result<(File, &Main<WlBuffer>)> {
-        let pos = self.pool.iter().rposition(|e| *e.buffer_state.borrow());
-        let size_bytes = size.0 * size.1 * std::mem::size_of::<u32>() as i32;
+    /// Returns a buffer the compositor is not currently reading from, growing
+    /// the pool if every existing one is still in use.
+    ///
+    /// `Ok(None)` means every buffer is still held and the pool is at its cap.
+    /// The caller must drop the frame rather than write to a held buffer,
+    /// which would leave the surface contents undefined.
+    fn get_buffer(
+        &mut self,
+        size: (i32, i32),
+        qh: &QueueHandle<WaylandState>,
+    ) -> std::io::Result<Option<(&mut File, &WlBuffer)>> {
+        // A wl_shm_pool size is an i32 on the wire, so the byte count has to
+        // fit one. Computing in i64 keeps an oversized surface from wrapping
+        // to a negative size and tripping a protocol error.
+        let size_bytes = i64::from(size.0) * i64::from(size.1) * std::mem::size_of::<u32>() as i64;
+        let size_bytes = i32::try_from(size_bytes).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("surface {}x{} is too large for an shm pool", size.0, size.1),
+            )
+        })?;
 
-        // If possible, take an older shm_pool and create a new buffer in it
-        if let Some(idx) = pos {
-            // Shm_pool not allowed to be truncated
-            if size_bytes > self.pool[idx].pool_size {
-                self.pool[idx].pool.resize(size_bytes);
-                self.pool[idx].pool_size = size_bytes;
+        let released: Vec<bool> = self
+            .pool
+            .iter()
+            .map(|e| e.released.load(Ordering::Acquire))
+            .collect();
+
+        let idx = match select_slot(&released, MAX_POOLED_BUFFERS) {
+            Slot::Reuse(idx) => idx,
+            Slot::Wait => return Ok(None),
+            Slot::Grow => {
+                let file = tempfile::tempfile()?;
+                // The compositor mmaps the pool as soon as it is created, so
+                // the file has to be that large before it is handed over --
+                // touching a mapping that extends past EOF is a SIGBUS.
+                file.set_len(size_bytes as u64)?;
+                let shm_pool = self.shm.create_pool(file.as_fd(), size_bytes, qh, ());
+                let (buffer, released) = Self::create_shm_buffer(&shm_pool, size, self.format, qh);
+
+                self.pool.push(Buffer {
+                    file,
+                    pool: shm_pool,
+                    pool_size: size_bytes,
+                    buffer,
+                    released,
+                    fb_size: size,
+                });
+
+                self.pool.len() - 1
             }
+        };
 
-            // Different buffer size
-            if self.pool[idx].fb_size != size {
-                let new_buffer = Self::create_shm_buffer(&self.pool[idx].pool, size, self.format);
-                let old_buffer = std::mem::replace(&mut self.pool[idx].buffer, new_buffer.0);
-                old_buffer.destroy();
-                self.pool[idx].fb_size = size;
-            }
+        let entry = &mut self.pool[idx];
 
-            Ok((self.pool[idx].fd.try_clone()?, &self.pool[idx].buffer))
-        } else {
-            let tempfile = tempfile::tempfile()?;
-            let shm_pool = self.shm.create_pool(
-                tempfile.as_raw_fd(),
-                size.0 * size.1 * std::mem::size_of::<u32>() as i32,
-            );
-            let buffer = Self::create_shm_buffer(&shm_pool, size, self.format);
+        // A wl_shm_pool may only ever grow. Extend the backing file first,
+        // for the same reason it is sized up front on creation.
+        if size_bytes > entry.pool_size {
+            entry.file.set_len(size_bytes as u64)?;
+            entry.pool.resize(size_bytes);
+            entry.pool_size = size_bytes;
+        }
 
-            self.pool.push(Buffer {
-                fd: tempfile,
-                pool: shm_pool,
-                pool_size: size_bytes,
-                buffer: buffer.0,
-                buffer_state: buffer.1,
-                fb_size: size,
-            });
+        if entry.fb_size != size {
+            let (buffer, released) = Self::create_shm_buffer(&entry.pool, size, self.format, qh);
+            let old = std::mem::replace(&mut entry.buffer, buffer);
+            old.destroy();
+            entry.released = released;
+            entry.fb_size = size;
+        }
 
-            Ok((
-                self.pool[self.pool.len() - 1].fd.try_clone()?,
-                &self.pool[self.pool.len() - 1].buffer,
-            ))
+        Ok(Some((&mut entry.file, &entry.buffer)))
+    }
+
+    /// Marks `buffer` as in use by the compositor. Called at attach time; the
+    /// matching `Release` event clears it again.
+    fn mark_attached(&self, buffer: &WlBuffer) {
+        if let Some(entry) = self.pool.iter().find(|e| &e.buffer == buffer) {
+            entry.released.store(false, Ordering::Release);
         }
     }
 }
 
+/// Event callbacks write here; `Window::update` drains it each frame.
+#[derive(Default)]
+struct WaylandState {
+    kb_events: Vec<wl_keyboard::Event>,
+    pt_events: Vec<wl_pointer::Event>,
+
+    /// Latest unacknowledged `xdg_surface::Configure` serial. Acknowledged when
+    /// the next frame is presented, so the ack is paired with actual content.
+    xdg_config: Option<u32>,
+    /// Latest `xdg_toplevel::Configure` size.
+    resolution: Option<(i32, i32)>,
+    closed: bool,
+}
+
+impl Dispatch<WlRegistry, GlobalListContents> for WaylandState {
+    fn event(
+        _: &mut Self,
+        _: &WlRegistry,
+        _: <WlRegistry as Proxy>::Event,
+        _: &GlobalListContents,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+    }
+}
+
+impl Dispatch<WlBuffer, Arc<AtomicBool>> for WaylandState {
+    fn event(
+        _: &mut Self,
+        _: &WlBuffer,
+        event: wl_buffer::Event,
+        released: &Arc<AtomicBool>,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        if let wl_buffer::Event::Release = event {
+            released.store(true, Ordering::Release);
+        }
+    }
+}
+
+impl Dispatch<WlKeyboard, ()> for WaylandState {
+    fn event(
+        state: &mut Self,
+        _: &WlKeyboard,
+        event: wl_keyboard::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        state.kb_events.push(event);
+    }
+}
+
+impl Dispatch<WlPointer, ()> for WaylandState {
+    fn event(
+        state: &mut Self,
+        _: &WlPointer,
+        event: wl_pointer::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        state.pt_events.push(event);
+    }
+}
+
+impl Dispatch<XdgWmBase, ()> for WaylandState {
+    fn event(
+        _: &mut Self,
+        xdg_wm_base: &XdgWmBase,
+        event: xdg_wm_base::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        if let xdg_wm_base::Event::Ping { serial } = event {
+            xdg_wm_base.pong(serial);
+        }
+    }
+}
+
+impl Dispatch<XdgSurface, ()> for WaylandState {
+    fn event(
+        state: &mut Self,
+        _: &XdgSurface,
+        event: xdg_surface::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        // Only the most recent configure needs acknowledging.
+        if let xdg_surface::Event::Configure { serial } = event {
+            state.xdg_config = Some(serial);
+        }
+    }
+}
+
+impl Dispatch<XdgToplevel, ()> for WaylandState {
+    fn event(
+        state: &mut Self,
+        _: &XdgToplevel,
+        event: xdg_toplevel::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        match event {
+            xdg_toplevel::Event::Configure { width, height, .. } => {
+                state.resolution = Some((width, height));
+            }
+            xdg_toplevel::Event::Close => {
+                state.closed = true;
+            }
+            _ => {}
+        }
+    }
+}
+
+delegate_noop!(WaylandState: ignore WlCompositor);
+delegate_noop!(WaylandState: ignore WlSurface);
+delegate_noop!(WaylandState: ignore WlShm);
+delegate_noop!(WaylandState: ignore WlShmPool);
+delegate_noop!(WaylandState: ignore WlSeat);
+delegate_noop!(WaylandState: ignore ZxdgDecorationManagerV1);
+delegate_noop!(WaylandState: ignore ZxdgToplevelDecorationV1);
+
 struct DisplayInfo {
-    attached_display: Attached<WlDisplay>,
-    surface: Main<WlSurface>,
-    xdg_surface: Main<XdgSurface>,
-    toplevel: Main<XdgToplevel>,
-    event_queue: EventQueue,
-    xdg_config: Rc<RefCell<Option<u32>>>,
+    conn: Connection,
+    event_queue: EventQueue<WaylandState>,
+    qh: QueueHandle<WaylandState>,
+    state: WaylandState,
+    surface: WlSurface,
+    xdg_surface: XdgSurface,
+    toplevel: XdgToplevel,
     cursor: wayland_cursor::CursorTheme,
-    cursor_surface: Main<WlSurface>,
-    _display: Display,
+    cursor_surface: WlSurface,
     buf_pool: BufferPool,
 }
 
 impl DisplayInfo {
     /// Accepts the size of the surface to be created, whether or not the alpha channel will be
     /// rendered, and whether or not server-side decorations will be used.
-    fn new(size: (i32, i32), alpha: bool, decorate: bool) -> Result<(Self, WaylandInput)> {
-        // Get the wayland display
-        let display = Display::connect_to_env().map_err(|e| {
+    fn new(size: (i32, i32), alpha: bool, decorate: bool) -> Result<(Self, WlKeyboard, WlPointer)> {
+        let conn = Connection::connect_to_env().map_err(|e| {
             Error::WindowCreate(format!("Failed to connect to the Wayland display: {:?}", e))
         })?;
-        let mut event_queue = display.create_event_queue();
 
-        // Access internal WlDisplay with a token
-        let attached_display = (*display).clone().attach(event_queue.token());
-        let globals = GlobalManager::new(&attached_display);
-
-        // Wait for the Wayland server to process all events
-        event_queue
-            .sync_roundtrip(&mut (), |_, _, _| unreachable!())
-            .map_err(|e| Error::WindowCreate(format!("Roundtrip failed: {:?}", e)))?;
+        let (globals, mut event_queue): (GlobalList, EventQueue<WaylandState>) =
+            registry_queue_init(&conn).map_err(|e| {
+                Error::WindowCreate(format!("Failed to retrieve the Wayland globals: {:?}", e))
+            })?;
+        let qh = event_queue.handle();
+        let mut state = WaylandState::default();
 
         // Version 5 is required for scroll events
-        let seat = globals
-            .instantiate_exact::<WlSeat>(5)
+        let seat: WlSeat = globals
+            .bind(&qh, 5..=5, ())
             .map_err(|e| Error::WindowCreate(format!("Failed to retrieve the WlSeat: {:?}", e)))?;
 
-        let input_devices = WaylandInput::new(&seat);
-        let compositor = globals.instantiate_exact::<WlCompositor>(4).map_err(|e| {
+        let keyboard = seat.get_keyboard(&qh, ());
+        let pointer = seat.get_pointer(&qh, ());
+
+        let compositor: WlCompositor = globals.bind(&qh, 4..=4, ()).map_err(|e| {
             Error::WindowCreate(format!("Failed to retrieve the compositor: {:?}", e))
         })?;
-        let shm = globals
-            .instantiate_exact::<WlShm>(1)
+        let shm: WlShm = globals
+            .bind(&qh, 1..=1, ())
             .map_err(|e| Error::WindowCreate(format!("Failed to create shared memory: {:?}", e)))?;
 
-        let surface = compositor.create_surface();
+        let surface = compositor.create_surface(&qh, ());
 
-        // Specify format
         let format = if alpha {
             Format::Argb8888
         } else {
             Format::Xrgb8888
         };
 
-        // Retrieve shm buffer for writing
         let mut buf_pool = BufferPool::new(shm.clone(), format);
-        let (mut tempfile, buffer) = buf_pool
-            .get_buffer(size)
-            .map_err(|e| Error::WindowCreate(format!("Failed to retrieve Buffer: {:?}", e)))?;
+        // The pool is empty here, so this always allocates rather than
+        // returning `None` for want of a free buffer.
+        let (file, buffer) = buf_pool
+            .get_buffer(size, &qh)
+            .map_err(|e| Error::WindowCreate(format!("Failed to retrieve Buffer: {:?}", e)))?
+            .ok_or_else(|| Error::WindowCreate("Failed to allocate a Buffer".to_owned()))?;
+        let buffer = buffer.clone();
 
         // Add a black canvas into the framebuffer
         let frame: Vec<u32> = vec![0xFF00_0000; (size.0 * size.1) as usize];
@@ -227,91 +424,64 @@ impl DisplayInfo {
                 frame.len() * std::mem::size_of::<u32>(),
             )
         };
-        tempfile
-            .write_all(slice)
+        file.write_all(slice)
             .map_err(|e| Error::WindowCreate(format!("Io Error: {:?}", e)))?;
-        tempfile
-            .flush()
+        file.flush()
             .map_err(|e| Error::WindowCreate(format!("Io Error: {:?}", e)))?;
 
-        let xdg_wm_base = globals.instantiate_exact::<XdgWmBase>(1).map_err(|e| {
+        let xdg_wm_base: XdgWmBase = globals.bind(&qh, 1..=1, ()).map_err(|e| {
             Error::WindowCreate(format!("Failed to retrieve the XdgWmBase: {:?}", e))
         })?;
 
-        // Reply to ping event
-        xdg_wm_base.quick_assign(|xdg_wm_base, event, _| {
-            use wayland_protocols::xdg_shell::client::xdg_wm_base::Event;
-
-            if let Event::Ping { serial } = event {
-                xdg_wm_base.pong(serial);
-            }
-        });
-
-        let xdg_surface = xdg_wm_base.get_xdg_surface(&surface);
-        let surface_clone = surface.clone();
-
-        // Handle configure event
-        xdg_surface.quick_assign(move |xdg_surface, event, _| {
-            use wayland_protocols::xdg_shell::client::xdg_surface::Event;
-
-            if let Event::Configure { serial } = event {
-                xdg_surface.ack_configure(serial);
-                surface_clone.commit();
-            }
-        });
-
-        // Assign the toplevel role and commit
-        let xdg_toplevel = xdg_surface.get_toplevel();
+        let xdg_surface = xdg_wm_base.get_xdg_surface(&surface, &qh, ());
+        let xdg_toplevel = xdg_surface.get_toplevel(&qh, ());
 
         if decorate {
-            if let Ok(decorations) = globals
-                .instantiate_exact::<ZxdgDecorationManagerV1>(1)
-                .map_err(|e| println!("Failed to create server-side surface decoration: {:?}", e))
-            {
-                decorations.get_toplevel_decoration(&xdg_toplevel);
-                decorations.destroy();
+            match globals.bind::<ZxdgDecorationManagerV1, _, _>(&qh, 1..=1, ()) {
+                Ok(decorations) => {
+                    decorations.get_toplevel_decoration(&xdg_toplevel, &qh, ());
+                    decorations.destroy();
+                }
+                Err(e) => println!("Failed to create server-side surface decoration: {:?}", e),
             }
         }
 
         surface.commit();
         event_queue
-            .sync_roundtrip(&mut (), |_, _, _| {})
+            .roundtrip(&mut state)
             .map_err(|e| Error::WindowCreate(format!("Roundtrip failed: {:?}", e)))?;
 
+        // The first configure has to be acknowledged before any content is
+        // attached; later ones are acknowledged as frames are presented.
+        if let Some(serial) = state.xdg_config.take() {
+            xdg_surface.ack_configure(serial);
+        }
+
         // Give the buffer to the surface and commit
-        surface.attach(Some(buffer), 0, 0);
+        surface.attach(Some(&buffer), 0, 0);
+        buf_pool.mark_attached(&buffer);
         surface.damage(0, 0, i32::MAX, i32::MAX);
         surface.commit();
 
-        let xdg_config = Rc::new(RefCell::new(None));
-        let xdg_config_clone = xdg_config.clone();
-
-        xdg_surface.quick_assign(move |_xdg_surface, event, _| {
-            use wayland_protocols::xdg_shell::client::xdg_surface::Event;
-
-            // Acknowledge only the last configure
-            if let Event::Configure { serial } = event {
-                *xdg_config_clone.borrow_mut() = Some(serial);
-            }
-        });
-
-        let cursor = wayland_cursor::CursorTheme::load(16, &shm);
-        let cursor_surface = compositor.create_surface();
+        let cursor = wayland_cursor::CursorTheme::load(&conn, shm.clone(), 16)
+            .map_err(|e| Error::WindowCreate(format!("Failed to load cursor theme: {:?}", e)))?;
+        let cursor_surface = compositor.create_surface(&qh, ());
 
         Ok((
             Self {
-                _display: display,
-                attached_display,
+                conn,
+                event_queue,
+                qh,
+                state,
                 surface,
                 xdg_surface,
                 toplevel: xdg_toplevel,
-                event_queue,
-                xdg_config,
                 cursor,
                 cursor_surface,
                 buf_pool,
             },
-            input_devices,
+            keyboard,
+            pointer,
         ))
     }
 
@@ -347,93 +517,35 @@ impl DisplayInfo {
 
     // Resizes when buffer is bigger or less
     fn update_framebuffer(&mut self, buffer: &[u32], size: (i32, i32)) -> std::io::Result<()> {
-        let (mut fd, buf) = self.buf_pool.get_buffer(size)?;
+        // Every buffer is still held by the compositor: drop this frame
+        // rather than write into one it may be scanning out. The previous
+        // frame stays on screen and the next call presents normally.
+        let (file, buf) = match self.buf_pool.get_buffer(size, &self.qh)? {
+            Some(entry) => entry,
+            None => return Ok(()),
+        };
+        let buf = buf.clone();
 
-        fd.seek(SeekFrom::Start(0))?;
+        file.seek(SeekFrom::Start(0))?;
 
         let slice = unsafe {
             std::slice::from_raw_parts(buffer.as_ptr() as *const u8, std::mem::size_of_val(buffer))
         };
 
-        fd.write_all(slice)?;
-        fd.flush()?;
+        file.write_all(slice)?;
+        file.flush()?;
 
         // Acknowledge the last configure event
-        if let Some(serial) = (*self.xdg_config.borrow_mut()).take() {
+        if let Some(serial) = self.state.xdg_config.take() {
             self.xdg_surface.ack_configure(serial);
         }
 
-        self.surface.attach(Some(buf), 0, 0);
+        self.surface.attach(Some(&buf), 0, 0);
+        self.buf_pool.mark_attached(&buf);
         self.surface.damage(0, 0, i32::MAX, i32::MAX);
         self.surface.commit();
 
         Ok(())
-    }
-
-    fn get_toplevel_info(&self) -> (ToplevelResolution, ToplevelClosed) {
-        let resolution = Rc::new(RefCell::new(None));
-        let closed = Rc::new(RefCell::new(false));
-
-        let resolution_clone = resolution.clone();
-        let closed_clone = closed.clone();
-
-        self.toplevel.quick_assign(move |_, event, _| {
-            use wayland_protocols::xdg_shell::client::xdg_toplevel::Event;
-
-            if let Event::Configure { width, height, .. } = event {
-                *resolution_clone.borrow_mut() = Some((width, height));
-            } else if let Event::Close = event {
-                *closed_clone.borrow_mut() = true;
-            }
-        });
-
-        (resolution, closed)
-    }
-}
-
-struct WaylandInput {
-    kb_events: mpsc::Receiver<wl_keyboard::Event>,
-    pt_events: mpsc::Receiver<wl_pointer::Event>,
-    _keyboard: Main<WlKeyboard>,
-    pointer: Main<WlPointer>,
-}
-
-impl WaylandInput {
-    fn new(seat: &Main<WlSeat>) -> Self {
-        let (keyboard, pointer) = (seat.get_keyboard(), seat.get_pointer());
-        let (kb_sender, kb_receiver) = mpsc::sync_channel(1024);
-
-        keyboard.quick_assign(move |_, event, _| {
-            kb_sender.send(event).unwrap();
-        });
-
-        let (pt_sender, pt_receiver) = mpsc::sync_channel(1024);
-
-        pointer.quick_assign(move |_, event, _| {
-            pt_sender.send(event).unwrap();
-        });
-
-        Self {
-            kb_events: kb_receiver,
-            pt_events: pt_receiver,
-            _keyboard: keyboard,
-            pointer,
-        }
-    }
-
-    #[inline]
-    fn get_pointer(&self) -> &Main<WlPointer> {
-        &self.pointer
-    }
-
-    #[inline]
-    fn iter_keyboard_events(&self) -> mpsc::TryIter<'_, wl_keyboard::Event> {
-        self.kb_events.try_iter()
-    }
-
-    #[inline]
-    fn iter_pointer_events(&self) -> mpsc::TryIter<'_, wl_pointer::Event> {
-        self.pt_events.try_iter()
     }
 }
 
@@ -472,12 +584,11 @@ pub struct Window {
     update_rate: UpdateRate,
     menu_counter: MenuHandle,
     menus: Vec<UnixMenu>,
-    input: WaylandInput,
+    _keyboard: WlKeyboard,
+    pointer: WlPointer,
     resizable: bool,
     // Temporary buffer
     buffer: Vec<u32>,
-    // Resolution, closed
-    toplevel_info: (ToplevelResolution, ToplevelClosed),
     pointer_visibility: bool,
 }
 
@@ -496,8 +607,23 @@ impl Window {
             Scale::X32 => 32,
         };
 
-        let (display, input) = DisplayInfo::new(
-            (width as i32 * scale, height as i32 * scale),
+        // `Scale::X32` on a large request can overflow an i32 here, which
+        // would reach the compositor as a nonsensical surface size.
+        let scaled = |v: usize| -> Result<i32> {
+            i32::try_from(v)
+                .ok()
+                .and_then(|v: i32| v.checked_mul(scale))
+                .ok_or_else(|| {
+                    Error::WindowCreate(format!(
+                        "{}x{} at {}x scale is too large",
+                        width, height, scale
+                    ))
+                })
+        };
+        let (scaled_width, scaled_height) = (scaled(width)?, scaled(height)?);
+
+        let (display, keyboard, pointer) = DisplayInfo::new(
+            (scaled_width, scaled_height),
             opts.transparency,
             !opts.borderless || opts.none,
         )?;
@@ -506,10 +632,8 @@ impl Window {
             display.set_title(name);
         }
         if !opts.resize || opts.none {
-            display.set_no_resize((width as i32 * scale, height as i32 * scale));
+            display.set_no_resize((scaled_width, scaled_height));
         }
-
-        let (resolution, closed) = display.get_toplevel_info();
 
         #[cfg(feature = "dlopen")]
         {
@@ -535,8 +659,8 @@ impl Window {
         Ok(Self {
             display,
 
-            width: width as i32 * scale,
-            height: height as i32 * scale,
+            width: scaled_width,
+            height: scaled_height,
 
             scale,
             bg_color: 0,
@@ -562,10 +686,10 @@ impl Window {
             update_rate: UpdateRate::new(),
             menu_counter: MenuHandle(0),
             menus: Vec::new(),
-            input,
+            _keyboard: keyboard,
+            pointer,
             resizable: opts.resize && !opts.none,
             buffer: Vec::with_capacity(width * height * scale as usize * scale as usize),
-            toplevel_info: (resolution, closed),
             pointer_visibility: true,
         })
     }
@@ -592,7 +716,7 @@ impl Window {
 
     #[inline]
     pub fn get_window_handle(&self) -> *mut c_void {
-        self.display.surface.as_ref().c_ptr() as *mut c_void
+        self.display.surface.id().as_ptr() as *mut c_void
     }
 
     #[inline]
@@ -670,10 +794,9 @@ impl Window {
 
     #[inline]
     pub fn get_position(&self) -> (isize, isize) {
-        let (x, y) = (0, 0);
-        // todo!("get_position");
-
-        (x as isize, y as isize)
+        // Wayland deliberately does not tell a client where its surface is on
+        // screen, so there is nothing truthful to report here.
+        (0, 0)
     }
 
     #[inline]
@@ -754,43 +877,56 @@ impl Window {
         unimplemented!()
     }
 
-    fn try_dispatch_events(&mut self) {
-        // as seen in https://docs.rs/wayland-client/0.28/wayland_client/struct.EventQueue.html
-        if let Err(e) = self.display.event_queue.display().flush() {
-            if e.kind() != std::io::ErrorKind::WouldBlock {
+    /// Pumps the socket. Returns `false` once the connection is gone, which
+    /// the caller turns into a close request: a compositor that disconnects
+    /// mid-run should end the window, not abort the process.
+    fn try_dispatch_events(&mut self) -> bool {
+        let display = &mut self.display;
+
+        if let Err(e) = display.event_queue.flush() {
+            if !is_would_block(&e) {
                 eprintln!("Error while trying to flush the wayland socket: {:?}", e);
             }
         }
 
-        if let Some(guard) = self.display.event_queue.prepare_read() {
-            if let Err(e) = guard.read_events() {
-                if e.kind() != std::io::ErrorKind::WouldBlock {
+        if let Err(e) = display.event_queue.dispatch_pending(&mut display.state) {
+            eprintln!("Wayland event dispatch failed: {:?}", e);
+            return false;
+        }
+
+        if let Some(guard) = display.event_queue.prepare_read() {
+            if let Err(e) = guard.read() {
+                if !is_would_block(&e) {
                     eprintln!(
                         "Error while trying to read from the wayland socket: {:?}",
                         e
                     );
+                    return false;
                 }
             }
         }
 
-        self.display
-            .event_queue
-            .dispatch_pending(&mut (), |_, _, _| {})
-            .map_err(|e| Error::WindowCreate(format!("Event dispatch failed: {:?}", e)))
-            .unwrap();
+        if let Err(e) = display.event_queue.dispatch_pending(&mut display.state) {
+            eprintln!("Wayland event dispatch failed: {:?}", e);
+            return false;
+        }
+
+        true
     }
 
     pub fn update(&mut self) {
-        self.try_dispatch_events();
+        if !self.try_dispatch_events() {
+            self.should_close = true;
+        }
 
-        if let Some(resize) = (*self.toplevel_info.0.borrow_mut()).take() {
+        if let Some(resize) = self.display.state.resolution.take() {
             // Don't try to resize to 0x0
             if self.resizable && resize != (0, 0) {
                 self.width = resize.0;
                 self.height = resize.1;
             }
         }
-        if *self.toplevel_info.1.borrow() {
+        if self.display.state.closed {
             self.should_close = true;
         }
 
@@ -799,14 +935,24 @@ impl Window {
         // events inline, so it is the one that has to split the phases.
         self.key_handler.snapshot_prev();
 
-        for event in self.input.iter_keyboard_events() {
+        for event in std::mem::take(&mut self.display.state.kb_events) {
             use wayland_client::protocol::wl_keyboard::Event;
 
             match event {
                 Event::Keymap { format, fd, size } => {
-                    let keymap = Self::handle_keymap(self.xkb_context, format, fd, size).unwrap();
-                    self.xkb_keymap = keymap;
-                    self.xkb_state = unsafe { ffi_dispatch!(XKBH, xkb_state_new, keymap) };
+                    match Self::handle_keymap(self.xkb_context, format, fd, size) {
+                        Ok(keymap) => {
+                            // Drop the previous keymap/state; the compositor
+                            // sends a fresh keymap whenever the layout changes.
+                            unsafe {
+                                ffi_dispatch!(XKBH, xkb_state_unref, self.xkb_state);
+                                ffi_dispatch!(XKBH, xkb_keymap_unref, self.xkb_keymap);
+                            }
+                            self.xkb_keymap = keymap;
+                            self.xkb_state = unsafe { ffi_dispatch!(XKBH, xkb_state_new, keymap) };
+                        }
+                        Err(e) => eprintln!("Failed to load the compositor keymap: {:?}", e),
+                    }
                 }
                 Event::Enter { .. } => {
                     self.active = true;
@@ -816,14 +962,16 @@ impl Window {
                 }
                 Event::Key { key, state, .. } => {
                     if !self.xkb_state.is_null() && !self.xkb_keymap.is_null() {
-                        Self::handle_key(
-                            self.xkb_keymap,
-                            self.xkb_state,
-                            key + KEY_XKB_OFFSET,
-                            state,
-                            &mut self.key_handler,
-                            &mut self.held,
-                        );
+                        if let WEnum::Value(state) = state {
+                            Self::handle_key(
+                                self.xkb_keymap,
+                                self.xkb_state,
+                                key + KEY_XKB_OFFSET,
+                                state,
+                                &mut self.key_handler,
+                                &mut self.held,
+                            );
+                        }
                     }
                 }
                 Event::Modifiers {
@@ -858,7 +1006,7 @@ impl Window {
         self.scroll_x = 0.;
         self.scroll_y = 0.;
 
-        for event in self.input.iter_pointer_events() {
+        for event in std::mem::take(&mut self.display.state.pt_events) {
             use wayland_client::protocol::wl_pointer::Event;
 
             match event {
@@ -871,26 +1019,10 @@ impl Window {
                     self.mouse_x = surface_x as f32;
                     self.mouse_y = surface_y as f32;
 
-                    self.input.get_pointer().set_cursor(
-                        serial,
-                        Some(&self.display.cursor_surface),
-                        0,
-                        0,
-                    );
                     self.display
                         .update_cursor(Self::decode_cursor(self.prev_cursor))
                         .unwrap();
-
-                    if self.pointer_visibility {
-                        self.input.get_pointer().set_cursor(
-                            serial,
-                            Some(&self.display.cursor_surface),
-                            0,
-                            0,
-                        );
-                    } else {
-                        self.input.get_pointer().set_cursor(serial, None, 0, 0);
-                    }
+                    self.apply_cursor(serial);
                 }
                 Event::Motion {
                     surface_x,
@@ -908,7 +1040,7 @@ impl Window {
                 } => {
                     use wayland_client::protocol::wl_pointer::ButtonState;
 
-                    let pressed = state == ButtonState::Pressed;
+                    let pressed = matches!(state, WEnum::Value(ButtonState::Pressed));
 
                     match button {
                         // Left mouse button
@@ -927,61 +1059,44 @@ impl Window {
                         ),
                     }
 
-                    if self.pointer_visibility {
-                        self.input.get_pointer().set_cursor(
-                            serial,
-                            Some(&self.display.cursor_surface),
-                            0,
-                            0,
-                        );
-                    } else {
-                        self.input.get_pointer().set_cursor(serial, None, 0, 0);
-                    }
+                    self.apply_cursor(serial);
                 }
                 Event::Axis { axis, value, .. } => {
                     use wayland_client::protocol::wl_pointer::Axis;
 
                     match axis {
-                        Axis::VerticalScroll => self.scroll_y = value as f32,
-                        Axis::HorizontalScroll => self.scroll_x = value as f32,
+                        WEnum::Value(Axis::VerticalScroll) => self.scroll_y = value as f32,
+                        WEnum::Value(Axis::HorizontalScroll) => self.scroll_x = value as f32,
                         _ => {}
                     }
-                }
-                Event::Frame => {
-                    // TODO
-                }
-                Event::AxisSource { axis_source } => {
-                    let _ = axis_source;
-                    // TODO
                 }
                 Event::AxisStop { axis, .. } => {
                     use wayland_client::protocol::wl_pointer::Axis;
 
                     match axis {
-                        Axis::VerticalScroll => self.scroll_y = 0.,
-                        Axis::HorizontalScroll => self.scroll_x = 0.,
+                        WEnum::Value(Axis::VerticalScroll) => self.scroll_y = 0.,
+                        WEnum::Value(Axis::HorizontalScroll) => self.scroll_x = 0.,
                         _ => {}
                     }
                 }
-                Event::AxisDiscrete { axis, discrete } => {
-                    let _ = (axis, discrete);
-                    // TODO
-                }
                 Event::Leave { serial, .. } => {
-                    if self.pointer_visibility {
-                        self.input.get_pointer().set_cursor(
-                            serial,
-                            Some(&self.display.cursor_surface),
-                            0,
-                            0,
-                        );
-                    } else {
-                        self.input.get_pointer().set_cursor(serial, None, 0, 0);
-                    }
+                    self.apply_cursor(serial);
                 }
                 _ => {}
             }
         }
+    }
+
+    /// Points the pointer at our cursor surface, or hides it entirely when the
+    /// cursor has been turned off.
+    #[inline]
+    fn apply_cursor(&self, serial: u32) {
+        let surface = if self.pointer_visibility {
+            Some(&self.display.cursor_surface)
+        } else {
+            None
+        };
+        self.pointer.set_cursor(serial, surface, 0, 0);
     }
 
     /// The keysym `key` produces at shift level 0 of the currently active
@@ -1192,12 +1307,12 @@ impl Window {
 
     fn handle_keymap(
         context: *mut xkb_ffi::xkb_context,
-        keymap: KeymapFormat,
-        fd: RawFd,
+        keymap: WEnum<KeymapFormat>,
+        fd: OwnedFd,
         len: u32,
     ) -> Result<*mut xkb_ffi::xkb_keymap> {
         match keymap {
-            KeymapFormat::XkbV1 => {
+            WEnum::Value(KeymapFormat::XkbV1) => {
                 unsafe {
                     // The file descriptor must be memory-mapped (with MAP_PRIVATE).
                     let addr = libc::mmap(
@@ -1205,7 +1320,7 @@ impl Window {
                         len as usize,
                         libc::PROT_READ,
                         libc::MAP_PRIVATE,
-                        fd,
+                        fd.as_raw_fd(),
                         0,
                     );
                     if addr == libc::MAP_FAILED {
@@ -1235,7 +1350,10 @@ impl Window {
                     }
                 }
             }
-            _ => unimplemented!("Only XKB keymaps are supported"),
+            other => Err(Error::WindowCreate(format!(
+                "Only XKB keymaps are supported, compositor sent {:?}",
+                other
+            ))),
         }
     }
 
@@ -1356,13 +1474,16 @@ impl Window {
     }
 }
 
+#[inline]
+fn is_would_block(e: &WaylandError) -> bool {
+    matches!(e, WaylandError::Io(io) if io.kind() == std::io::ErrorKind::WouldBlock)
+}
+
 impl HasWindowHandle for Window {
     fn window_handle(&self) -> std::result::Result<WindowHandle<'_>, HandleError> {
-        let raw_display_surface = self.display.surface.as_ref().c_ptr() as *mut c_void;
-        let display_surface = match NonNull::new(raw_display_surface) {
-            Some(display_surface) => display_surface,
-            None => unimplemented!("null display surface"),
-        };
+        let surface = self.display.surface.id().as_ptr();
+        let display_surface =
+            NonNull::new(surface as *mut c_void).ok_or(HandleError::Unavailable)?;
 
         let handle = WaylandWindowHandle::new(display_surface);
         let raw_handle = RawWindowHandle::Wayland(handle);
@@ -1372,17 +1493,8 @@ impl HasWindowHandle for Window {
 
 impl HasDisplayHandle for Window {
     fn display_handle(&self) -> std::result::Result<DisplayHandle<'_>, HandleError> {
-        let raw_display = self
-            .display
-            .attached_display
-            .clone()
-            .detach()
-            .as_ref()
-            .c_ptr() as *mut c_void;
-        let display = match NonNull::new(raw_display) {
-            Some(display) => display,
-            None => unimplemented!("null display"),
-        };
+        let raw_display = self.display.conn.backend().display_ptr();
+        let display = NonNull::new(raw_display as *mut c_void).ok_or(HandleError::Unavailable)?;
         let handle = WaylandDisplayHandle::new(display);
         let raw_handle = RawDisplayHandle::Wayland(handle);
         unsafe { Ok(DisplayHandle::borrow_raw(raw_handle)) }
@@ -1747,5 +1859,56 @@ xkb_symbols "minifb_test" {
         km.press(&mut keys, KP1);
 
         assert_eq!(keys.get_keys(), vec![Key::NumPad1]);
+    }
+}
+
+#[cfg(test)]
+mod buffer_pool_tests {
+    use super::{select_slot, Slot, MAX_POOLED_BUFFERS};
+
+    #[test]
+    fn empty_pool_grows() {
+        assert_eq!(select_slot(&[], MAX_POOLED_BUFFERS), Slot::Grow);
+    }
+
+    #[test]
+    fn released_buffer_is_reused() {
+        assert_eq!(
+            select_slot(&[false, true], MAX_POOLED_BUFFERS),
+            Slot::Reuse(1)
+        );
+    }
+
+    #[test]
+    fn lowest_released_index_wins() {
+        assert_eq!(
+            select_slot(&[false, true, true], MAX_POOLED_BUFFERS),
+            Slot::Reuse(1)
+        );
+    }
+
+    #[test]
+    fn all_busy_under_cap_grows() {
+        assert_eq!(select_slot(&[false, false], MAX_POOLED_BUFFERS), Slot::Grow);
+    }
+
+    /// At the cap with nothing released there is no safe buffer to write to,
+    /// so the frame is dropped rather than scribbled into a held buffer.
+    #[test]
+    fn all_busy_at_cap_waits() {
+        let busy = [false; MAX_POOLED_BUFFERS];
+        assert_eq!(select_slot(&busy, MAX_POOLED_BUFFERS), Slot::Wait);
+    }
+
+    /// A released buffer must still win at the cap, rather than dropping a
+    /// frame that had somewhere safe to go.
+    #[test]
+    fn release_at_cap_is_preferred_over_waiting() {
+        let mut slots = [false; MAX_POOLED_BUFFERS];
+        slots[MAX_POOLED_BUFFERS - 1] = true;
+        assert_eq!(
+            select_slot(&slots, MAX_POOLED_BUFFERS),
+            Slot::Reuse(MAX_POOLED_BUFFERS - 1)
+        );
     }
 }

--- a/src/os/posix/wayland.rs
+++ b/src/os/posix/wayland.rs
@@ -68,6 +68,21 @@ const KEY_MOUSE_BTN3: u32 = 274;
 const KEY_MOUSE_BTN8: u32 = 275;
 const KEY_MOUSE_BTN9: u32 = 276;
 
+/// Byte count of a `width` x `height` ARGB framebuffer, or `None` if the
+/// dimensions are not positive or the total does not fit the `i32` a
+/// `wl_shm_pool` size is sent as. Every path that accepts a size — window
+/// creation, a compositor configure, and the pool itself — goes through this,
+/// so `width * height` can never overflow downstream.
+fn framebuffer_bytes(width: i32, height: i32) -> Option<i32> {
+    if width <= 0 || height <= 0 {
+        return None;
+    }
+    i64::from(width)
+        .checked_mul(i64::from(height))
+        .and_then(|px| px.checked_mul(std::mem::size_of::<u32>() as i64))
+        .and_then(|bytes| i32::try_from(bytes).ok())
+}
+
 /// Which slot `BufferPool::get_buffer` should draw from.
 #[derive(Debug, PartialEq, Eq)]
 enum Slot {
@@ -157,11 +172,7 @@ impl BufferPool {
         size: (i32, i32),
         qh: &QueueHandle<WaylandState>,
     ) -> std::io::Result<Option<(&mut File, &WlBuffer)>> {
-        // A wl_shm_pool size is an i32 on the wire, so the byte count has to
-        // fit one. Computing in i64 keeps an oversized surface from wrapping
-        // to a negative size and tripping a protocol error.
-        let size_bytes = i64::from(size.0) * i64::from(size.1) * std::mem::size_of::<u32>() as i64;
-        let size_bytes = i32::try_from(size_bytes).map_err(|_| {
+        let size_bytes = framebuffer_bytes(size.0, size.1).ok_or_else(|| {
             std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
                 format!("surface {}x{} is too large for an shm pool", size.0, size.1),
@@ -621,6 +632,12 @@ impl Window {
                 })
         };
         let (scaled_width, scaled_height) = (scaled(width)?, scaled(height)?);
+        if framebuffer_bytes(scaled_width, scaled_height).is_none() {
+            return Err(Error::WindowCreate(format!(
+                "{}x{} at {}x scale is too large",
+                width, height, scale
+            )));
+        }
 
         let (display, keyboard, pointer) = DisplayInfo::new(
             (scaled_width, scaled_height),
@@ -886,6 +903,7 @@ impl Window {
         if let Err(e) = display.event_queue.flush() {
             if !is_would_block(&e) {
                 eprintln!("Error while trying to flush the wayland socket: {:?}", e);
+                return false;
             }
         }
 
@@ -919,11 +937,17 @@ impl Window {
             self.should_close = true;
         }
 
-        if let Some(resize) = self.display.state.resolution.take() {
-            // Don't try to resize to 0x0
-            if self.resizable && resize != (0, 0) {
-                self.width = resize.0;
-                self.height = resize.1;
+        if let Some((width, height)) = self.display.state.resolution.take() {
+            if self.resizable {
+                // The compositor picks these, so a size the framebuffer maths
+                // cannot represent has to be refused rather than stored; 0x0
+                // is the normal "you choose" configure.
+                if framebuffer_bytes(width, height).is_some() {
+                    self.width = width;
+                    self.height = height;
+                } else if (width, height) != (0, 0) {
+                    eprintln!("Ignoring unusable configure size {}x{}", width, height);
+                }
             }
         }
         if self.display.state.closed {
@@ -1864,7 +1888,33 @@ xkb_symbols "minifb_test" {
 
 #[cfg(test)]
 mod buffer_pool_tests {
-    use super::{select_slot, Slot, MAX_POOLED_BUFFERS};
+    use super::{framebuffer_bytes, select_slot, Slot, MAX_POOLED_BUFFERS};
+
+    #[test]
+    fn framebuffer_bytes_is_width_times_height_times_four() {
+        assert_eq!(framebuffer_bytes(640, 480), Some(640 * 480 * 4));
+    }
+
+    #[test]
+    fn framebuffer_bytes_rejects_non_positive() {
+        assert_eq!(framebuffer_bytes(0, 480), None);
+        assert_eq!(framebuffer_bytes(640, 0), None);
+        assert_eq!(framebuffer_bytes(-1, 480), None);
+        assert_eq!(framebuffer_bytes(640, -1), None);
+    }
+
+    /// `i32::MAX * i32::MAX * 4` exceeds `i64::MAX`, so the intermediate
+    /// product has to be checked, not just the final narrowing to i32.
+    #[test]
+    fn framebuffer_bytes_survives_the_largest_dimensions() {
+        assert_eq!(framebuffer_bytes(i32::MAX, i32::MAX), None);
+    }
+
+    #[test]
+    fn framebuffer_bytes_rejects_a_total_larger_than_i32() {
+        // Dimensions are individually fine; the byte count is not.
+        assert_eq!(framebuffer_bytes(40_000, 40_000), None);
+    }
 
     #[test]
     fn empty_pool_grows() {


### PR DESCRIPTION
Moves the Wayland backend from the unmaintained 0.29 line to wayland-client 0.31 / wayland-protocols 0.32 / wayland-cursor 0.31.

The 0.29 event model (`Main<T>` + `quick_assign`) no longer exists; events now arrive through `Dispatch` impls on one state type, which queues keyboard and pointer events for `Window::update` to drain. The xkbcommon path is unchanged — level-0 keysym derivation, modifier tracking, held-key release bookkeeping and `add_char` all carried over, and `key_level_tests` still covers them.

`wayland-client` needs the `system` feature: `raw-window-handle` has to hand out a real `wl_surface*`/`wl_display*`, which only the libwayland backend can produce. `dlopen` still selects runtime loading vs linking, so the default build links neither libwayland nor libxkbcommon, as before.

Bugs fixed by the rewrite:

- Buffer release tracking. The flag was set on `wl_buffer::Release` and never cleared, and a resize dropped the new flag, so from frame 3 on a buffer was reused whether or not the compositor had released it. It is now the buffer's dispatch user data, cleared on attach. With every buffer held and the pool at its cap the frame is dropped rather than written into a buffer being scanned out.
- The shm file is sized before the pool is created and grown before the pool is — a mapping past EOF is a SIGBUS.
- `sync_channel(1024)` was filled and drained on the same thread, so an event burst could block dispatch with nothing draining it. Events queue in a `Vec` instead.
- The keymap fd is an `OwnedFd` and is closed; a keymap change unrefs the previous keymap and state.
- A malformed or non-XKB keymap is an error, not a panic. A compositor disconnect during `update()` closes the window instead of panicking.

Sizes and input coming from the compositor are validated rather than trusted:

- One `SurfaceSize` type carries a checked width, height and ARGB byte count, and `new()` is its only constructor, so holding one is the proof the size was checked and nothing downstream revalidates. Window creation, the configure path and the shm pool all take one. This replaces a first attempt at the check that could itself overflow: `i32::MAX * i32::MAX * 4` exceeds `i64::MAX`, so the guard meant to reject an oversized window panicked on it.
- Configure dimensions reached `scale_buffer`'s `i32` multiply unvalidated. They are now refused if unusable, and a configure may zero either axis on its own to leave that dimension to the client — a `(0, 600)` configure applies to the height instead of being dropped as a pair.
- An unknown `wl_pointer` `ButtonState` was read as a release and could clear a button still being held. It is ignored now, matching the key and axis handlers.
- A non-`WouldBlock` flush error was only logged, so a broken pipe left the window open despite the read and dispatch paths closing it.
- A keycode arrives as a compositor-supplied `u32` and was offset into xkb's numbering with a plain add, so a large one panicked in debug builds and wrapped to a low, valid-looking keycode in release ones.
- The keymap mapping was taken on trust. `mmap` does not check the length the compositor sends against the file behind the fd, so a short fd mapped cleanly and only faulted once xkbcommon read it, and a keymap with no terminator sent the parser's scan past the end of the mapping. Both are refused before parsing.
- A keymap the backend cannot use was logged and otherwise ignored, leaving the previous keymap and state live, so a compositor withdrawing its layout had subsequent keycodes translated through one it had already taken back. Translation stops instead, and keys held at that point are released.
- An `xdg_toplevel::Configure` size was published independently of the `xdg_surface::Configure` serial that closes the sequence, so a dispatch round ending between the two left a frame committing one configure's dimensions while acknowledging another's. The size is held pending until the serial arrives and the two are published together.

Drops nix 0.24, memoffset, wayland-commons and xml-rs; no duplicate crate versions remain.

Verified on Hyprland 0.56.2: examples run clean, keys and modifiers inject correctly via `wtype`, and `get_size` tracks the compositor's configures across a resize. 33 unit + 34 doctests pass. `cargo fmt --check` is clean and `cargo clippy --all-targets` reports exactly the same set of pre-existing warnings as master, across the wayland, wayland+x11, x11 and default feature sets.

Closes #318
Closes #408
Closes #409
Closes #410
Closes https://github.com/emoon/rust_minifb/pull/375
